### PR TITLE
Resolve Motorola periodic disconnect issue

### DIFF
--- a/src/entities/umac/subcomp/bs_sched.rs
+++ b/src/entities/umac/subcomp/bs_sched.rs
@@ -1,4 +1,35 @@
-use crate::{saps::tmv::{enums::logical_chans::LogicalChannel, {TmvUnitdataReq, TmvUnitdataReqSlot}}, common::{address::TetraAddress, bitbuffer::BitBuffer, tdma_time::TdmaTime, tetra_common::Todo}, entities::{lmac::components::scramble::SCRAMB_INIT, mle::pdus::{d_mle_sync::DMleSync, d_mle_sysinfo::DMleSysinfo}, umac::{enums::{access_assign_dl_usage::AccessAssignDlUsage, access_assign_ul_usage::AccessAssignUlUsage, basic_slotgrant_cap_alloc::BasicSlotgrantCapAlloc, basic_slotgrant_granting_delay::BasicSlotgrantGrantingDelay, reservation_requirement::ReservationRequirement}, fields::basic_slotgrant::BasicSlotgrant, pdus::{access_assign::{AccessAssign, AccessField}, access_assign_fr18::AccessAssignFr18, mac_resource::MacResource, mac_sync::MacSync, mac_sysinfo::MacSysinfo}, subcomp::fillbits::write_fill_bits}}, unimplemented_log};
+use crate::{
+    common::{
+        address::TetraAddress, bitbuffer::BitBuffer, tdma_time::TdmaTime, tetra_common::Todo,
+    },
+    entities::{
+        lmac::components::scramble::SCRAMB_INIT,
+        mle::pdus::{d_mle_sync::DMleSync, d_mle_sysinfo::DMleSysinfo},
+        umac::{
+            enums::{
+                access_assign_dl_usage::AccessAssignDlUsage,
+                access_assign_ul_usage::AccessAssignUlUsage,
+                basic_slotgrant_cap_alloc::BasicSlotgrantCapAlloc,
+                basic_slotgrant_granting_delay::BasicSlotgrantGrantingDelay,
+                reservation_requirement::ReservationRequirement,
+            },
+            fields::basic_slotgrant::BasicSlotgrant,
+            pdus::{
+                access_assign::{AccessAssign, AccessField},
+                access_assign_fr18::AccessAssignFr18,
+                mac_resource::MacResource,
+                mac_sync::MacSync,
+                mac_sysinfo::MacSysinfo,
+            },
+            subcomp::fillbits::write_fill_bits,
+        },
+    },
+    saps::tmv::{
+        enums::logical_chans::LogicalChannel,
+        {TmvUnitdataReq, TmvUnitdataReqSlot},
+    },
+    unimplemented_log,
+};
 
 /// We submit this many TX timeslots ahead of the current time
 pub const MACSCHED_TX_AHEAD: usize = 1;
@@ -28,7 +59,6 @@ pub struct TimeslotSchedule {
 
 #[derive(Debug)]
 pub struct BsChannelScheduler {
-    
     pub cur_ts: TdmaTime,
     scrambling_code: Option<u32>,
     precomps: Option<PrecomputedUmacPdus>,
@@ -45,10 +75,10 @@ pub enum DlSchedElem {
     RandomAccessAck(TetraAddress),
 
     /// A slotgrant response, which has to be transmitted with high priority or the delay numbers will be off
-    /// ssi and BasicSlotgrant are provided. 
+    /// ssi and BasicSlotgrant are provided.
     Grant(TetraAddress, BasicSlotgrant),
 
-    /// A MAC-RESOURCE PDU. May be split into fragments upon processing, in which case a FragBuf will be inserted after processing the resource. 
+    /// A MAC-RESOURCE PDU. May be split into fragments upon processing, in which case a FragBuf will be inserted after processing the resource.
     Resource(MacResource, BitBuffer),
 
     /// A FragBuf containing remaining non-transmitted information after a MAC-RESOURCE start has been transmitted
@@ -60,13 +90,19 @@ const EMPTY_SCHED_ELEM: TimeslotSchedule = TimeslotSchedule {
     ul2: None,
     dl: None,
 };
-const EMPTY_SCHED_CHANNEL: [TimeslotSchedule; MACSCHED_NUM_FRAMES] = [EMPTY_SCHED_ELEM; MACSCHED_NUM_FRAMES];
+const EMPTY_SCHED_CHANNEL: [TimeslotSchedule; MACSCHED_NUM_FRAMES] =
+    [EMPTY_SCHED_ELEM; MACSCHED_NUM_FRAMES];
 const EMPTY_SCHED: [[TimeslotSchedule; MACSCHED_NUM_FRAMES]; 4] = [EMPTY_SCHED_CHANNEL; 4];
 
 impl BsChannelScheduler {
     pub fn new() -> Self {
         BsChannelScheduler {
-            cur_ts: TdmaTime {t: 0, f: 0, m: 0, h: 0}, // Intentionally invalid, updated in tick function
+            cur_ts: TdmaTime {
+                t: 0,
+                f: 0,
+                m: 0,
+                h: 0,
+            }, // Intentionally invalid, updated in tick function
             scrambling_code: None,
             precomps: None,
             dltx_queues: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
@@ -96,10 +132,9 @@ impl BsChannelScheduler {
     }
 
     pub fn ts_to_sched_index(&self, ts: &TdmaTime) -> usize {
-        let to_index = (ts.f as usize - 1) + ((ts.m as usize - 1) * 18) + ((ts.h as usize* 18 * 60));
-        to_index % MACSCHED_NUM_FRAMES       
+        let to_index = (ts.f as usize - 1) + ((ts.m as usize - 1) * 18) + (ts.h as usize * 18 * 60);
+        to_index % MACSCHED_NUM_FRAMES
     }
-
 
     ///////// UPLINK GRANT PROCESSING /////////
 
@@ -107,21 +142,37 @@ impl BsChannelScheduler {
     /// If num_slots is 1, is_halfslot may specifiy whether only a half slot is needed
     /// Returns (opportunities_to_skip, Vec<timestamps_of_granted_slots>)
     /// Returns None if no suitable opportunity is found in the schedule
-    pub fn ul_find_grant_opportunity(&self, ts: u8, num_slots: usize, is_halfslot: bool) -> Option<(usize, Vec<TdmaTime>)> {
-
+    pub fn ul_find_grant_opportunity(
+        &self,
+        ts: u8,
+        num_slots: usize,
+        is_halfslot: bool,
+    ) -> Option<(usize, Vec<TdmaTime>)> {
         let mut grant_timeslots = Vec::with_capacity(num_slots);
         let mut opportunities_skipped = 0;
 
-        assert!(!is_halfslot || num_slots == 1, "is_halfslot set for num_slots > 1");
-        
+        assert!(
+            !is_halfslot || num_slots == 1,
+            "is_halfslot set for num_slots > 1"
+        );
+
         for dist in 1..MACSCHED_NUM_FRAMES {
             // let candidate_t = self.cur_ts.add_timeslots(dist as i32 * 4);
             // Base off of internal perception of time, convert to UL time
             // Below may crash someday, but I'd want to investigate that situation
             let candidate_t = self.cur_ts.add_timeslots(dist as i32 * 4 - 2);
-            assert!(candidate_t.t == ts, "ul_find_grant_opportunity: candidate_t.ts {} does not match requested ts {}. Please report this to developer. ", candidate_t.t, ts);
-            
-            tracing::debug!("ul_find_grant_opportunity: considering candidate ul_ts {}, have {:?}", candidate_t, grant_timeslots);
+            assert!(
+                candidate_t.t == ts,
+                "ul_find_grant_opportunity: candidate_t.ts {} does not match requested ts {}. Please report this to developer. ",
+                candidate_t.t,
+                ts
+            );
+
+            tracing::debug!(
+                "ul_find_grant_opportunity: considering candidate ul_ts {}, have {:?}",
+                candidate_t,
+                grant_timeslots
+            );
 
             if self.cur_ts.is_mandatory_clch() {
                 // Not an opportunity; skip
@@ -131,8 +182,9 @@ impl BsChannelScheduler {
             let index = self.ts_to_sched_index(&candidate_t);
             let elem = &self.sched[ts as usize - 1][index];
             // tracing::debug!("ul_find_grant_opportunity: sched[{}] ts {}: {:?}", index, candidate_t, elem);
-            if (elem.ul1.is_none() && elem.ul2.is_none()) || (is_halfslot && (elem.ul1.is_none() || elem.ul2.is_none())) {
-
+            if (elem.ul1.is_none() && elem.ul2.is_none())
+                || (is_halfslot && (elem.ul1.is_none() || elem.ul2.is_none()))
+            {
                 // Free UL slot, add this timeslot to result vec
                 grant_timeslots.push(candidate_t);
                 // continue;
@@ -154,26 +206,46 @@ impl BsChannelScheduler {
 
     /// Reserves all slots designated in a grant option
     /// If only one halfslot is needed, returns 1 or 2 designating which slot was reserved
-    pub fn ul_reserve_grant(&mut self, ssi: u32, grant_timestamps: Vec<TdmaTime>, is_halfslot: bool) -> u8 {
+    pub fn ul_reserve_grant(
+        &mut self,
+        ssi: u32,
+        grant_timestamps: Vec<TdmaTime>,
+        is_halfslot: bool,
+    ) -> u8 {
         assert!(!grant_timestamps.is_empty());
         assert!(!is_halfslot || grant_timestamps.len() == 1);
         // let ts = grant_timestamps[0].t as usize;
         for ts in grant_timestamps {
             let index = self.ts_to_sched_index(&ts);
-            
+
             let elem: &mut TimeslotSchedule = &mut self.sched[ts.t as usize - 1][index];
             if is_halfslot {
                 if elem.ul1.is_none() {
                     elem.ul1 = Some(ssi);
                     return 1;
                 } else {
-                    assert!(elem.ul2.is_none(), "ul_reserve_grant: ul2 already set for ts {:?}, ssi {}", ts, ssi);
+                    assert!(
+                        elem.ul2.is_none(),
+                        "ul_reserve_grant: ul2 already set for ts {:?}, ssi {}",
+                        ts,
+                        ssi
+                    );
                     elem.ul2 = Some(ssi);
                     return 2;
                 }
             } else {
-                assert!(elem.ul1.is_none(), "ul_reserve_grant: ul1 already set for ts {:?}, ssi {}", ts, ssi);
-                assert!(elem.ul2.is_none(), "ul_reserve_grant: ul2 already set for ts {:?}, ssi {}", ts, ssi);
+                assert!(
+                    elem.ul1.is_none(),
+                    "ul_reserve_grant: ul1 already set for ts {:?}, ssi {}",
+                    ts,
+                    ssi
+                );
+                assert!(
+                    elem.ul2.is_none(),
+                    "ul_reserve_grant: ul2 already set for ts {:?}, ssi {}",
+                    ts,
+                    ssi
+                );
                 elem.ul1 = Some(ssi);
                 elem.ul2 = Some(ssi);
             }
@@ -183,38 +255,53 @@ impl BsChannelScheduler {
         0
     }
 
-
-    /// Tries to find a way to satisfy a granting request, and reserves the slots in the schedule. 
+    /// Tries to find a way to satisfy a granting request, and reserves the slots in the schedule.
     /// If successful, returns a BasicSlotgrant with the granting delay and capacity allocation.
-    pub fn ul_process_cap_req(&mut self, timeslot: u8, addr: TetraAddress, res_req: &ReservationRequirement) -> Option<BasicSlotgrant> {
-
+    pub fn ul_process_cap_req(
+        &mut self,
+        timeslot: u8,
+        addr: TetraAddress,
+        res_req: &ReservationRequirement,
+    ) -> Option<BasicSlotgrant> {
         let is_halfslot = res_req == &ReservationRequirement::Req1Subslot;
-        let requested_cap = if is_halfslot {1} else {res_req.to_req_slotcount()};
+        let requested_cap = if is_halfslot {
+            1
+        } else {
+            res_req.to_req_slotcount()
+        };
 
         // Find a suitable grant opportunity
         let grant_op = self.ul_find_grant_opportunity(timeslot, requested_cap, is_halfslot);
 
-        tracing::debug!("ul_process_cap_req: addr {}, res_req {:?}, requested_cap {}, is_halfslot {}, grant_op: {:?}", 
-            addr, res_req, requested_cap, is_halfslot, grant_op);
+        tracing::debug!(
+            "ul_process_cap_req: addr {}, res_req {:?}, requested_cap {}, is_halfslot {}, grant_op: {:?}",
+            addr,
+            res_req,
+            requested_cap,
+            is_halfslot,
+            grant_op
+        );
 
         // If found, reserve the slots and return a BasicSlotgrant
         if let Some((skips, grant_timestamps)) = grant_op {
-
             // Reserve the target granting opportunity. Get subslot (only relevant for halfslot reservation)
             let subslot = self.ul_reserve_grant(addr.ssi, grant_timestamps, is_halfslot);
-                    
+
             // Build BasicSlotgrant response element
             let cap_alloc = if res_req == &ReservationRequirement::Req1Subslot {
                 match subslot {
                     1 => BasicSlotgrantCapAlloc::FirstSubslotGranted,
                     2 => BasicSlotgrantCapAlloc::SecondSubslotGranted,
-                    _ => unreachable!("ul_process_cap_req: subslot must be 1 or 2, got {}", subslot),
+                    _ => unreachable!(
+                        "ul_process_cap_req: subslot must be 1 or 2, got {}",
+                        subslot
+                    ),
                 }
             } else {
                 BasicSlotgrantCapAlloc::from_req_slotcount(requested_cap)
             };
             let grant_delay = if skips == 0 {
-                BasicSlotgrantGrantingDelay::CapAllocAtNextOpportunity 
+                BasicSlotgrantGrantingDelay::CapAllocAtNextOpportunity
             } else {
                 BasicSlotgrantGrantingDelay::DelayNOpportunities(skips as u8)
             };
@@ -223,16 +310,19 @@ impl BsChannelScheduler {
                 granting_delay: grant_delay,
             })
         } else {
-            tracing::warn!("ul_process_cap_req: no suitable grant opportunity found for addr {}, res_req {:?}", addr, res_req);
+            tracing::warn!(
+                "ul_process_cap_req: no suitable grant opportunity found for addr {}, res_req {:?}",
+                addr,
+                res_req
+            );
             None
         }
-    }    
+    }
 
     fn ul_get_usage(&self, ts: TdmaTime) -> AccessAssignUlUsage {
-        
         let ul_sched = &self.sched[ts.t as usize - 1][self.ts_to_sched_index(&ts)];
         assert!(ul_sched.ul1.is_some() || ul_sched.ul2.is_none());
-        
+
         if ul_sched.ul1.is_some() && ul_sched.ul2.is_some() {
             AccessAssignUlUsage::AssignedOnly
         } else if ul_sched.ul1.is_some() {
@@ -242,24 +332,37 @@ impl BsChannelScheduler {
         }
     }
 
-
     ////////// DOWNLINK SCHEDULING /////////
 
     /// Registers that we should transmit a MAC-RESOURCE or similar with a grant, somewhere this tick
     pub fn dl_enqueue_grant(&mut self, timeslot: u8, addr: TetraAddress, grant: BasicSlotgrant) {
-        tracing::debug!("dl_enqueue_grant: ts {} enqueueing PDU {:?} for addr {}", timeslot, grant, addr);
+        tracing::debug!(
+            "dl_enqueue_grant: ts {} enqueueing PDU {:?} for addr {}",
+            timeslot,
+            grant,
+            addr
+        );
         let elem = DlSchedElem::Grant(addr, grant);
         self.dltx_queues[timeslot as usize - 1].push(elem);
     }
 
     pub fn dl_enqueue_random_access_ack(&mut self, timeslot: u8, addr: TetraAddress) {
-        tracing::debug!("dl_enqueue_random_access_ack: ts {} enqueueing random access acknowledgementfor addr {}", timeslot, addr);
+        tracing::debug!(
+            "dl_enqueue_random_access_ack: ts {} enqueueing random access acknowledgementfor addr {}",
+            timeslot,
+            addr
+        );
         let elem = DlSchedElem::RandomAccessAck(addr);
         self.dltx_queues[timeslot as usize - 1].push(elem);
     }
 
     pub fn dl_enqueue_tma(&mut self, timeslot: u8, pdu: MacResource, sdu: BitBuffer) {
-        tracing::debug!("dl_enqueue_tma: ts {} enqueueing PDU {:?} SDU {}", timeslot, pdu, sdu.dump_bin());
+        tracing::debug!(
+            "dl_enqueue_tma: ts {} enqueueing PDU {:?} SDU {}",
+            timeslot,
+            pdu,
+            sdu.dump_bin()
+        );
         let elem = DlSchedElem::Resource(pdu, sdu);
         self.dltx_queues[timeslot as usize - 1].push(elem);
     }
@@ -273,22 +376,21 @@ impl BsChannelScheduler {
     }
 
     /// Takes a block or None value.
-    /// If block is present and some signalling channel, and space is available, 
-    /// adds a trailing Null PDU. 
-    /// If blk is None, returns None. 
+    /// If block is present and some signalling channel, and space is available,
+    /// adds a trailing Null PDU.
+    /// If blk is None, returns None.
     /// Otherwise, returns blk unchanged (eg. for SYNC, broadcast, etc).
     pub fn try_add_null_pdus(&mut self, blk: Option<TmvUnitdataReq>) -> Option<TmvUnitdataReq> {
-        
         // A null pdu in a slot:
         // 0000000000010000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-        // Oddly, the fill_bits ind is set to 0, while a fill bit is indeed present to fill the slot. 
-        // We replicate that behavior here. 
+        // Oddly, the fill_bits ind is set to 0, while a fill bit is indeed present to fill the slot.
+        // We replicate that behavior here.
         if let Some(mut b) = blk {
-            if      b.logical_channel == LogicalChannel::Stch ||
-                    b.logical_channel == LogicalChannel::SchHd ||
-                    b.logical_channel == LogicalChannel::SchF {
+            if b.logical_channel == LogicalChannel::Stch
+                || b.logical_channel == LogicalChannel::SchHd
+                || b.logical_channel == LogicalChannel::SchF
+            {
                 if b.mac_block.get_len_remaining() >= NULL_PDU_LEN_BITS {
-
                     tracing::trace!("try_add_null_pdus: closing blk with Null PDU");
 
                     // We have room for a Null PDU
@@ -302,32 +404,36 @@ impl BsChannelScheduler {
                     pdu.to_bitbuf(&mut b.mac_block);
 
                     // TODO FIXME: it's possibly the best idea to still add fill bits trailing this null pdu.
-                    // Check real-world captures. 
+                    // Check real-world captures.
                 } else {
-                    unimplemented!("try_add_null_pdus: Not enough space for Null PDU in block, got {} bits remaining", b.mac_block.get_len_remaining());
+                    unimplemented!(
+                        "try_add_null_pdus: Not enough space for Null PDU in block, got {} bits remaining",
+                        b.mac_block.get_len_remaining()
+                    );
                 }
             }
-            
+
             Some(b)
         } else {
-            None        
+            None
         }
-
-        
     }
 
     /// Returns a mutable reference to the first scheduled resource for the given timeslot and address
-    pub fn dl_get_scheduled_resource_for_ssi(&mut self, ts: TdmaTime, addr: &TetraAddress) -> Option<&mut DlSchedElem> {
-
+    pub fn dl_get_scheduled_resource_for_ssi(
+        &mut self,
+        ts: TdmaTime,
+        addr: &TetraAddress,
+    ) -> Option<&mut DlSchedElem> {
         let queue = &mut self.dltx_queues[ts.t as usize - 1];
-        
+
         for index in 0..queue.len() {
             let elem = &mut queue[index];
             if let DlSchedElem::Resource(pdu, _sdu) = elem {
                 if let Some(pdu_ssi) = pdu.addr {
                     if pdu_ssi.ssi == addr.ssi {
                         // Found a resource for this address
-                        return queue.get_mut(index)
+                        return queue.get_mut(index);
                     }
                 }
             }
@@ -337,7 +443,11 @@ impl BsChannelScheduler {
     }
 
     /// Make a minimal resource to contain a grant or a random access acknowledgement
-    pub fn dl_make_minimal_resource(addr: &TetraAddress, grant: Option<BasicSlotgrant>, random_access_ack: bool) -> MacResource {
+    pub fn dl_make_minimal_resource(
+        addr: &TetraAddress,
+        grant: Option<BasicSlotgrant>,
+        random_access_ack: bool,
+    ) -> MacResource {
         let mut pdu = MacResource {
             fill_bits: false, // updated later
             pos_of_grant: 0,
@@ -356,13 +466,15 @@ impl BsChannelScheduler {
     }
 
     pub fn dl_take_all_grants_and_acks(&mut self, timeslot: u8) -> Vec<DlSchedElem> {
-
-        let queue = &mut self.dltx_queues[timeslot as usize- 1];
+        let queue = &mut self.dltx_queues[timeslot as usize - 1];
         let mut taken = Vec::new();
 
         let mut i = 0;
         while i < queue.len() {
-            if matches!(queue[i], DlSchedElem::Grant(_, _) | DlSchedElem::RandomAccessAck(_)) {
+            if matches!(
+                queue[i],
+                DlSchedElem::Grant(_, _) | DlSchedElem::RandomAccessAck(_)
+            ) {
                 let elem = queue.remove(i);
                 taken.push(elem);
             } else {
@@ -373,13 +485,11 @@ impl BsChannelScheduler {
     }
 
     pub fn dl_integrate_sched_elems_for_timeslot(&mut self, ts: TdmaTime) {
-        
         // Remove all grants and acks from queue and collect them into a vec
         let grants_and_acks = self.dl_take_all_grants_and_acks(ts.t);
 
         // Process grants and acks
         for elem in grants_and_acks {
-            
             // Try to find existing resource for this address
             let addr = match &elem {
                 DlSchedElem::Grant(addr, _) => addr,
@@ -390,32 +500,45 @@ impl BsChannelScheduler {
 
             match mac_resource {
                 Some(DlSchedElem::Resource(pdu, _sdu)) => {
-                    
                     // Integrate grant into the resource
                     match &elem {
                         DlSchedElem::Grant(_, grant) => {
-                            tracing::debug!("dl_integrate_sched_elems_for_timeslot: Integrating grant {:?} into resource for addr {}", grant, addr);
+                            tracing::debug!(
+                                "dl_integrate_sched_elems_for_timeslot: Integrating grant {:?} into resource for addr {}",
+                                grant,
+                                addr
+                            );
                             pdu.slot_granting_element = Some(grant.clone());
-                        },
+                        }
                         DlSchedElem::RandomAccessAck(_) => {
-                            tracing::debug!("dl_integrate_sched_elems_for_timeslot: Integrating ack into resource for addr {}", addr);
+                            tracing::debug!(
+                                "dl_integrate_sched_elems_for_timeslot: Integrating ack into resource for addr {}",
+                                addr
+                            );
                             pdu.random_access_flag = true;
-                        },
+                        }
                         _ => panic!(),
                     }
-                },
+                }
                 None => {
                     // No resource for this address was found, create a new one
-                    
+
                     let pdu = match &elem {
                         DlSchedElem::Grant(_, grant) => {
-                            tracing::debug!("dl_integrate_sched_elems_for_timeslot: Creating new resource for addr {} with grant {:?}", addr, grant);
+                            tracing::debug!(
+                                "dl_integrate_sched_elems_for_timeslot: Creating new resource for addr {} with grant {:?}",
+                                addr,
+                                grant
+                            );
                             Self::dl_make_minimal_resource(addr, Some(grant.clone()), false)
-                        },
+                        }
                         DlSchedElem::RandomAccessAck(_) => {
-                            tracing::debug!("dl_integrate_sched_elems_for_timeslot: Creating new resource for addr {} with ack", addr);
+                            tracing::debug!(
+                                "dl_integrate_sched_elems_for_timeslot: Creating new resource for addr {} with ack",
+                                addr
+                            );
                             Self::dl_make_minimal_resource(addr, None, true)
-                        },
+                        }
                         _ => panic!(),
                     };
 
@@ -428,9 +551,9 @@ impl BsChannelScheduler {
         }
     }
 
-    /// Return first queued grant. 
-    /// If none; return first in-progress fragmented message. 
-    /// If none; return first to-be-transmitted resource. 
+    /// Return first queued grant.
+    /// If none; return first in-progress fragmented message.
+    /// If none; return first to-be-transmitted resource.
     /// If none, return None.
     pub fn dl_take_prioritized_sched_item(&mut self, ts: u8) -> Option<DlSchedElem> {
         // Map 1-based ts to 0-based index, bail on 0 or out of range.
@@ -448,7 +571,10 @@ impl BsChannelScheduler {
         }
 
         // Return Resources last
-        if let Some(i) = q.iter().position(|e| matches!(e, DlSchedElem::Resource(_, _))) {
+        if let Some(i) = q
+            .iter()
+            .position(|e| matches!(e, DlSchedElem::Resource(_, _)))
+        {
             return Some(q.remove(i));
         }
 
@@ -458,19 +584,23 @@ impl BsChannelScheduler {
     pub fn tick_start(&mut self, ts: TdmaTime) {
         // Increment current time
         self.cur_ts = self.cur_ts.add_timeslots(1);
-        assert!(ts == self.cur_ts, "BsChannelScheduler tick_start: ts mismatch, expected {}, got {}", self.cur_ts, ts);
+        assert!(
+            ts == self.cur_ts,
+            "BsChannelScheduler tick_start: ts mismatch, expected {}, got {}",
+            self.cur_ts,
+            ts
+        );
     }
 
     /// Prepares a scheduled FUTURE timeslot for transfer to lmac and transmission
     /// Generates BBK block
-    /// If the timeslot is not full, generates SYNC SB1/SB2 blocks. 
+    /// If the timeslot is not full, generates SYNC SB1/SB2 blocks.
     /// Increments cur_ts by one timeslot.
     /// Caller should check timestamp of returned DlTxElem to prevent desync
     pub fn finalize_ts_for_tick(&mut self) -> TmvUnitdataReqSlot {
-
         // We finalize a FUTURE slot: cur_ts plus some number of timeslots
         let ts = self.cur_ts.add_timeslots(MACSCHED_TX_AHEAD as i32);
-        
+
         // TODO FIXME allocate only if we have something to put in it
         let mut buf = BitBuffer::new(SCH_F_CAP);
 
@@ -484,31 +614,35 @@ impl BsChannelScheduler {
                 tracing::error!("got violating element {:?}", opt);
                 panic!();
             }
-            
+
             match opt {
-                Some(sched_elem) => {
-                    match sched_elem {
-                        DlSchedElem::Broadcast(_) => {
-                            unimplemented_log!("finalize_ts_for_tick: Broadcast scheduling not implemented");
-                        },
-
-                        DlSchedElem::Resource(mut pdu, mut sdu) => {
-                            
-                            let sdu_bits = sdu.get_len();
-                            let num_fill_bits = pdu.update_len_and_fill_ind(sdu_bits);
-
-                            pdu.to_bitbuf(&mut buf);
-                            buf.copy_bits(&mut sdu, sdu_bits);
-                            write_fill_bits(&mut buf, Some(num_fill_bits));
-                            tracing::debug!("<- finalized {:?} sdu {}", pdu, sdu.dump_bin());
-                        },
-                        
-                        DlSchedElem::FragBuf(_) => {
-                            unimplemented_log!("finalize_ts_for_tick: FragBuf scheduling not implemented");
-                        }
-
-                        _ => panic!("finalize_ts_for_tick: Unexpected DlSchedElem type: {:?}", sched_elem)
+                Some(sched_elem) => match sched_elem {
+                    DlSchedElem::Broadcast(_) => {
+                        unimplemented_log!(
+                            "finalize_ts_for_tick: Broadcast scheduling not implemented"
+                        );
                     }
+
+                    DlSchedElem::Resource(mut pdu, mut sdu) => {
+                        let sdu_bits = sdu.get_len();
+                        let num_fill_bits = pdu.update_len_and_fill_ind(sdu_bits);
+
+                        pdu.to_bitbuf(&mut buf);
+                        buf.copy_bits(&mut sdu, sdu_bits);
+                        write_fill_bits(&mut buf, Some(num_fill_bits));
+                        tracing::debug!("<- finalized {:?} sdu {}", pdu, sdu.dump_bin());
+                    }
+
+                    DlSchedElem::FragBuf(_) => {
+                        unimplemented_log!(
+                            "finalize_ts_for_tick: FragBuf scheduling not implemented"
+                        );
+                    }
+
+                    _ => panic!(
+                        "finalize_ts_for_tick: Unexpected DlSchedElem type: {:?}",
+                        sched_elem
+                    ),
                 },
                 None => {
                     // No more items to process, we can finalize this timeslot
@@ -516,7 +650,7 @@ impl BsChannelScheduler {
                 }
             }
         }
-        
+
         // Check if any signalling message was put
         let mut elem = if buf.get_pos() == 0 {
             // Put default SYNC/SYSINFO frame
@@ -524,7 +658,7 @@ impl BsChannelScheduler {
                 ts,
                 blk1: None,
                 blk2: None, // MAY be populated later
-                bbk: None, // WILL be populated later
+                bbk: None,  // WILL be populated later
             }
         } else {
             TmvUnitdataReqSlot {
@@ -535,40 +669,36 @@ impl BsChannelScheduler {
                     scrambling_code: self.scrambling_code.unwrap(),
                 }),
                 blk2: None, // MAY be populated later
-                bbk: None, // WILL be populated later
+                bbk: None,  // WILL be populated later
             }
         };
 
         // FIXME implement that sched can contain more items, buf for now, fail if that's the case
         // assert!(self.dl_take_schedule_item(&ts).is_none(), "finalize_ts_for_tick: dl_take_schedule_item should return None, but got {:?}", elem);
 
-
-        // By default, UL is CommonOnly. 
+        // By default, UL is CommonOnly.
         // If we encounter a subslot grant, we set this to CommonAndAssigned
         // If the full slot is granted (or two subslot grants are encountered), we set this to AssignedOnly
         // let ul_usage = self.ul_get_usage(ts);
-        
-        if elem.bbk.is_none() {
 
+        if elem.bbk.is_none() {
             // let index = self.ts_to_sched_index(&ts);
             // let sched = &self.sched[ts.t as usize - 1][index];
 
             // Generate BBK block
             let mut aach_bb = BitBuffer::new(14);
             if ts.f != 18 {
-                
                 let mut aach = AccessAssign::default();
-                
-                if elem.blk1.as_ref().is_some_and(|b| 
-                        b.logical_channel == LogicalChannel::Stch ||
-                        b.logical_channel.is_traffic()) {
+
+                if elem.blk1.as_ref().is_some_and(|b| {
+                    b.logical_channel == LogicalChannel::Stch || b.logical_channel.is_traffic()
+                }) {
                     // aach.dl_usage = Some(AccessAssignDlUsage::Traffic());
                     unimplemented!();
                 }
 
                 match ts.t {
                     1 => {
-
                         // STRATEGY 1, always send UL CommonAndAssigned
                         // This seems to cause problems with Motorola, which may refuse random access on anything but CommonOnly
                         // Yields something like: 01000010000100
@@ -589,37 +719,36 @@ impl BsChannelScheduler {
                         // Set access fields based on usage
                         match aach.ul_usage {
                             AccessAssignUlUsage::CommonOnly => {
-                                aach.f1_af1 = Some(AccessField{
+                                aach.f1_af1 = Some(AccessField {
                                     access_code: 0,
                                     base_frame_len: 4,
                                 });
-                                aach.f2_af2 = Some(AccessField{
+                                aach.f2_af2 = Some(AccessField {
                                     access_code: 0,
                                     base_frame_len: 4,
                                 });
-
-                            },
-                            AccessAssignUlUsage::CommonAndAssigned | 
-                            AccessAssignUlUsage::AssignedOnly => {
-                                aach.f2_af = Some(AccessField{
+                            }
+                            AccessAssignUlUsage::CommonAndAssigned
+                            | AccessAssignUlUsage::AssignedOnly => {
+                                aach.f2_af = Some(AccessField {
                                     access_code: 0,
                                     base_frame_len: 4,
                                 });
-                            },
-                            _ => { 
+                            }
+                            _ => {
                                 // Traffic or unallocated; no AccessFields
                             }
                         }
-                    },
+                    }
                     2..=4 => {
                         // Additional channels, unallocated except we sent a chanalloc
                         // Those are currently unimplemented, so, unallocated it is
                         aach.dl_usage = AccessAssignDlUsage::Unallocated;
                         aach.ul_usage = AccessAssignUlUsage::Unallocated;
-                    },
+                    }
                     _ => panic!("finalize_ts_for_tick: invalid timeslot {}", ts.t),
                 }
-                
+
                 // if ts.t < 4 {
                 //     // ts 1,2,3
                 //     aach.dl_usage = AccessAssignDlUsage::CommonControl;
@@ -639,9 +768,7 @@ impl BsChannelScheduler {
                 // TODO FIXME: Access field defaults are possibly not great
                 // TODO FIXME: support assigned control
                 aach.to_bitbuf(&mut aach_bb);
-                
             } else {
-                
                 // Fr18
                 let aach = AccessAssignFr18 {
                     ul_usage: AccessAssignUlUsage::CommonOnly,
@@ -657,64 +784,90 @@ impl BsChannelScheduler {
                 };
                 // TODO FIXME: Access field defaults are possibly not great
                 aach.to_bitbuf(&mut aach_bb);
-            }            
-            
+            }
+
             let bbk = TmvUnitdataReq {
                 logical_channel: LogicalChannel::Aach,
-                mac_block: aach_bb,                
+                mac_block: aach_bb,
                 scrambling_code: self.scrambling_code.unwrap(),
             };
-            
+
             elem.bbk = Some(bbk);
-        } else { panic!(); }
+        } else {
+            panic!();
+        }
 
         // tracing::trace!("finalize_ts_for_tick: have {}{}{}",
         //     if elem.bbk.is_some() { "bbk " } else { "" },
         //     if elem.blk1.is_some() { "blk1 " } else { "" },
         //     if elem.blk2.is_some() { "blk2 " } else { "" });
 
-        // Check if blk1 populated. If not, we put a sync block. 
+        // Populate blk1 if empty: BSCH on frame 18, SCH/HD on other frames
         if elem.blk1.is_none() {
+            if ts.f == 18 {
+                // Frame 18: BSCH (SDB burst) with SYNC
+                let mut buf = BitBuffer::new(60);
+                if let Some(ref mut precomps) = self.precomps {
+                    precomps.mac_sync.time = ts;
+                    precomps.mac_sync.to_bitbuf(&mut buf);
+                    precomps.mle_sync.to_bitbuf(&mut buf);
+                } else {
+                    panic!("precomps not available");
+                };
 
-            // Update time and write MAC-SYNC and MLE-SYNC to blk1
-            // tracing::trace!("finalize_ts_for_tick: putting default SYNC");
-            let mut buf = BitBuffer::new(60); // Exactly 60
-            if let Some(ref mut precomps) = self.precomps {
-                precomps.mac_sync.time = ts;
-                precomps.mac_sync.to_bitbuf(&mut buf);
-                precomps.mle_sync.to_bitbuf(&mut buf);
-            } else { panic!("precomps not available"); };
-            
-            elem.blk1 = Some(TmvUnitdataReq {
-                logical_channel: LogicalChannel::Bsch,
-                mac_block: buf,
-                scrambling_code: SCRAMB_INIT,
-            });
+                elem.blk1 = Some(TmvUnitdataReq {
+                    logical_channel: LogicalChannel::Bsch,
+                    mac_block: buf,
+                    scrambling_code: SCRAMB_INIT,
+                });
+            } else {
+                // Frames 1-17: SCH/HD (NDB burst) with NULL PDU
+                let mut buf = BitBuffer::new(124);
+                let mut pdu = MacResource {
+                    fill_bits: false,
+                    length_ind: 2,
+                    addr: None,
+                    ..Default::default()
+                };
+                let _ = pdu.update_len_and_fill_ind(0);
+                pdu.to_bitbuf(&mut buf);
+
+                elem.blk1 = Some(TmvUnitdataReq {
+                    logical_channel: LogicalChannel::SchHd,
+                    mac_block: buf,
+                    scrambling_code: self.scrambling_code.unwrap(),
+                });
+            }
         }
 
         // Check if second block may still be populated (blk1 is half-slot and blk2 is None)
         let blk1_lchan = elem.blk1.as_ref().unwrap().logical_channel;
         assert!(blk1_lchan != LogicalChannel::Stch, "unimplemented");
 
-        if elem.blk2.is_none() && (blk1_lchan == LogicalChannel::Bsch || blk1_lchan == LogicalChannel::SchHd || blk1_lchan == LogicalChannel::Stch) {
-            
-            // tracing::trace!("finalize_ts_for_tick: putting default SYSINFO");
-
-            // Check blk1 is indeed short (124 for half-slot or 60 for SYNC)
+        // Populate blk2 with SYSINFO if blk1 is half-slot
+        if elem.blk2.is_none()
+            && (blk1_lchan == LogicalChannel::Bsch
+                || blk1_lchan == LogicalChannel::SchHd
+                || blk1_lchan == LogicalChannel::Stch)
+        {
             assert!(elem.blk1.as_ref().unwrap().mac_block.get_len() <= 124);
-            
-            let mut buf = BitBuffer::new(124); // Exactly 124
-            
-            // Write MAC-SYSINFO
+
+            let mut buf = BitBuffer::new(124);
+
+            // Update hyperframe and write MAC-SYSINFO (alternating sysinfo1/sysinfo2)
+            let precomps = self.precomps.as_mut().unwrap();
             if ts.t % 2 == 1 {
-                // Odd ts, write sysinfo1
-                self.precomps.as_ref().unwrap().mac_sysinfo1.to_bitbuf(&mut buf);
+                precomps.mac_sysinfo1.hyperframe_number = Some(ts.h);
+                precomps.mac_sysinfo1.to_bitbuf(&mut buf);
             } else {
-                // Even ts, write sysinfo2
-                self.precomps.as_ref().unwrap().mac_sysinfo2.to_bitbuf(&mut buf);
+                precomps.mac_sysinfo2.hyperframe_number = Some(ts.h);
+                precomps.mac_sysinfo2.to_bitbuf(&mut buf);
             }
-            // Append MLE-SYSINFO and store blk2
-            self.precomps.as_ref().unwrap().mle_sysinfo.to_bitbuf(&mut buf);
+            self.precomps
+                .as_ref()
+                .unwrap()
+                .mle_sysinfo
+                .to_bitbuf(&mut buf);
 
             elem.blk2 = Some(TmvUnitdataReq {
                 logical_channel: LogicalChannel::Bnch,
@@ -725,7 +878,7 @@ impl BsChannelScheduler {
             // TESTING CODE: DL/UL SYNC CHECKING
             // let mut buf = BitBuffer::new(124); // Exactly 124
             // buf.write_bits(0xFFFF, 16);
-            // buf.write_bits(ts.t as u64, 8); 
+            // buf.write_bits(ts.t as u64, 8);
             // buf.write_bits(ts.f as u64, 8);
             // buf.write_bits(ts.m as u64, 8);
             // buf.write_bits(ts.h as u64, 16);
@@ -738,11 +891,20 @@ impl BsChannelScheduler {
             // });
         } else {
             // We're done, no blk2 needed. Just a quick check blk1 is indeed long
-            assert!(elem.blk1.as_ref().unwrap().mac_block.get_len() == 268, "blk1 is long, but blk2 is set!");
+            assert!(
+                elem.blk1.as_ref().unwrap().mac_block.get_len() == 268,
+                "blk1 is long, but blk2 is set!"
+            );
         }
 
-        assert!(elem.bbk.is_some(), "finalize_ts_for_tick: BBK block is not set, this should not happen");
-        assert!(elem.blk1.is_some(), "finalize_ts_for_tick: blk1 block is not set, this should not happen");
+        assert!(
+            elem.bbk.is_some(),
+            "finalize_ts_for_tick: BBK block is not set, this should not happen"
+        );
+        assert!(
+            elem.blk1.is_some(),
+            "finalize_ts_for_tick: blk1 block is not set, this should not happen"
+        );
 
         // If signalling channels are here, and there is spare room, we need to close them with a Null pdu
         elem.blk1 = self.try_add_null_pdus(elem.blk1);
@@ -787,16 +949,29 @@ impl BsChannelScheduler {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
 
-    use crate::{common::{address::{SsiType, TetraAddress}, debug::setup_logging_default}, entities::{mle::fields::bs_service_details::BsServiceDetails, umac::{enums::sysinfo_opt_field_flag::SysinfoOptFieldFlag, fields::{sysinfo_default_def_for_access_code_a::SysinfoDefaultDefForAccessCodeA, sysinfo_ext_services::SysinfoExtendedServices}}}};
+    use crate::{
+        common::{
+            address::{SsiType, TetraAddress},
+            debug::setup_logging_default,
+        },
+        entities::{
+            mle::fields::bs_service_details::BsServiceDetails,
+            umac::{
+                enums::sysinfo_opt_field_flag::SysinfoOptFieldFlag,
+                fields::{
+                    sysinfo_default_def_for_access_code_a::SysinfoDefaultDefForAccessCodeA,
+                    sysinfo_ext_services::SysinfoExtendedServices,
+                },
+            },
+        },
+    };
 
     use super::*;
 
     pub fn get_testing_slotter() -> BsChannelScheduler {
-
         let _ = setup_logging_default(None);
 
         // TODO FIXME make all parameters configurable
@@ -835,13 +1010,13 @@ mod tests {
             ms_txpwr_max_cell: 5,
             rxlev_access_min: 3,
             access_parameter: 7,
-            radio_dl_timeout: 3,
+            radio_dl_timeout: 15,
             cck_id: None,
             hyperframe_number: Some(0),
             option_field: SysinfoOptFieldFlag::DefaultDefForAccCodeA,
             ts_common_frames: None,
             default_access_code: Some(def_access),
-            ext_services: None
+            ext_services: None,
         };
 
         let sysinfo2 = MacSysinfo {
@@ -860,14 +1035,14 @@ mod tests {
             option_field: SysinfoOptFieldFlag::ExtServicesBroadcast,
             ts_common_frames: None,
             default_access_code: None,
-            ext_services: Some(ext_services)
+            ext_services: Some(ext_services),
         };
 
         let mle_sysinfo_pdu = DMleSysinfo {
             location_area: 2,
             subscriber_class: 65535, // All subscriber classes allowed
             bs_service_details: BsServiceDetails {
-                registration: true, 
+                registration: true,
                 deregistration: true,
                 priority_cell: false,
                 no_minimum_mode: true,
@@ -878,7 +1053,7 @@ mod tests {
                 sndcp_service: false,
                 aie_service: false,
                 advanced_link: false,
-            }
+            },
         };
 
         let mac_sync_pdu = MacSync {
@@ -895,18 +1070,18 @@ mod tests {
             mcc: 204,
             mnc: 1337,
             neighbor_cell_broadcast: 2,
-            cell_load_ca: 0, 
+            cell_load_ca: 0,
             late_entry_supported: true,
         };
 
         let precomps = PrecomputedUmacPdus {
             mac_sysinfo1: sysinfo1,
             mac_sysinfo2: sysinfo2,
-            mle_sysinfo: mle_sysinfo_pdu,        
+            mle_sysinfo: mle_sysinfo_pdu,
             mac_sync: mac_sync_pdu,
             mle_sync: mle_sync_pdu,
-        }; 
-        
+        };
+
         let mut sched = BsChannelScheduler::new();
         sched.set_scrambling_code(1);
         sched.set_precomputed_msgs(precomps);
@@ -914,75 +1089,169 @@ mod tests {
         sched
     }
 
-
-    #[test] 
+    #[test]
     fn test_halfslot_grants() {
         let mut sched = get_testing_slotter();
         let resreq = ReservationRequirement::Req1Subslot;
-        let addr = TetraAddress { encrypted: false, ssi_type: SsiType::Issi, ssi: 1234 };
+        let addr = TetraAddress {
+            encrypted: false,
+            ssi_type: SsiType::Issi,
+            ssi: 1234,
+        };
         let grant1 = sched.ul_process_cap_req(1, addr, &resreq);
         tracing::info!("grant1: {:?}", grant1);
-        assert!(grant1.is_some(), "ul_process_cap_req should return Some, but got None");
+        assert!(
+            grant1.is_some(),
+            "ul_process_cap_req should return Some, but got None"
+        );
 
-        let u1 = sched.ul_get_usage(TdmaTime { t: 1, f: 1, m: 1, h: 0 });
-        let u2 = sched.ul_get_usage(TdmaTime { t: 1, f: 2, m: 1, h: 0 });
-        let u3 = sched.ul_get_usage(TdmaTime { t: 1, f: 3, m: 1, h: 0 });
+        let u1 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 1,
+            m: 1,
+            h: 0,
+        });
+        let u2 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 2,
+            m: 1,
+            h: 0,
+        });
+        let u3 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 3,
+            m: 1,
+            h: 0,
+        });
         tracing::info!("usage ts 1/2/3: {:?}/{:?}/{:?}", u1, u2, u3);
 
         let cap_alloc1 = grant1.unwrap().capacity_allocation;
-        assert_eq!(cap_alloc1, BasicSlotgrantCapAlloc::FirstSubslotGranted, "ul_process_cap_req should return FirstSubslotGranted, but got {:?}", cap_alloc1);
+        assert_eq!(
+            cap_alloc1,
+            BasicSlotgrantCapAlloc::FirstSubslotGranted,
+            "ul_process_cap_req should return FirstSubslotGranted, but got {:?}",
+            cap_alloc1
+        );
         let grant2 = sched.ul_process_cap_req(1, addr, &resreq);
         tracing::info!("grant2: {:?}", grant2);
-        assert!(grant2.is_some(), "ul_process_cap_req should return Some, but got None");
+        assert!(
+            grant2.is_some(),
+            "ul_process_cap_req should return Some, but got None"
+        );
         let cap_alloc2 = grant2.unwrap().capacity_allocation;
-        assert_eq!(cap_alloc2, BasicSlotgrantCapAlloc::SecondSubslotGranted, "ul_process_cap_req should return SecondSubslotGranted, but got {:?}", cap_alloc2);
+        assert_eq!(
+            cap_alloc2,
+            BasicSlotgrantCapAlloc::SecondSubslotGranted,
+            "ul_process_cap_req should return SecondSubslotGranted, but got {:?}",
+            cap_alloc2
+        );
 
-        let u1 = sched.ul_get_usage(TdmaTime { t: 1, f: 1, m: 1, h: 0 });
-        let u2 = sched.ul_get_usage(TdmaTime { t: 1, f: 2, m: 1, h: 0 });
-        let u3 = sched.ul_get_usage(TdmaTime { t: 1, f: 3, m: 1, h: 0 });
+        let u1 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 1,
+            m: 1,
+            h: 0,
+        });
+        let u2 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 2,
+            m: 1,
+            h: 0,
+        });
+        let u3 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 3,
+            m: 1,
+            h: 0,
+        });
         tracing::info!("usage ts 1/2/3: {:?}/{:?}/{:?}", u1, u2, u3);
-
     }
 
-    #[test] 
+    #[test]
     fn test_halfslot_and_fullslot_grant() {
         let mut sched = get_testing_slotter();
         let resreq1 = ReservationRequirement::Req1Subslot;
-        let addr = TetraAddress { encrypted: false, ssi_type: SsiType::Issi, ssi: 1234 };
-        
+        let addr = TetraAddress {
+            encrypted: false,
+            ssi_type: SsiType::Issi,
+            ssi: 1234,
+        };
+
         sched.dump_ul_schedule(true);
         let grant1 = sched.ul_process_cap_req(1, addr, &resreq1);
         tracing::info!("grant1: {:?}", grant1);
-        
-        let u1 = sched.ul_get_usage(TdmaTime { t: 1, f: 1, m: 1, h: 0 });
-        let u2 = sched.ul_get_usage(TdmaTime { t: 1, f: 2, m: 1, h: 0 });
-        let u3 = sched.ul_get_usage(TdmaTime { t: 1, f: 3, m: 1, h: 0 });
+
+        let u1 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 1,
+            m: 1,
+            h: 0,
+        });
+        let u2 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 2,
+            m: 1,
+            h: 0,
+        });
+        let u3 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 3,
+            m: 1,
+            h: 0,
+        });
         tracing::info!("usage ts 1/2/3: {:?}/{:?}/{:?}", u1, u2, u3);
 
         assert!(grant1.is_some());
         let cap_alloc1 = grant1.unwrap().capacity_allocation;
         assert_eq!(cap_alloc1, BasicSlotgrantCapAlloc::FirstSubslotGranted);
-        
+
         sched.dump_ul_schedule(true);
         let resreq2 = ReservationRequirement::Req3Slots;
-        let Some(grant2) = sched.ul_process_cap_req(1, addr, &resreq2) else { panic!() };
+        let Some(grant2) = sched.ul_process_cap_req(1, addr, &resreq2) else {
+            panic!()
+        };
         tracing::info!("grant2: {:?}", grant2);
         sched.dump_ul_schedule(true);
-        
-        let u1 = sched.ul_get_usage(TdmaTime { t: 1, f: 1, m: 1, h: 0 });
-        let u2 = sched.ul_get_usage(TdmaTime { t: 1, f: 2, m: 1, h: 0 });
-        let u3 = sched.ul_get_usage(TdmaTime { t: 1, f: 3, m: 1, h: 0 });
+
+        let u1 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 1,
+            m: 1,
+            h: 0,
+        });
+        let u2 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 2,
+            m: 1,
+            h: 0,
+        });
+        let u3 = sched.ul_get_usage(TdmaTime {
+            t: 1,
+            f: 3,
+            m: 1,
+            h: 0,
+        });
         tracing::info!("usage ts 1/2/3: {:?}/{:?}/{:?}", u1, u2, u3);
 
-        assert_eq!(grant2.capacity_allocation, BasicSlotgrantCapAlloc::Grant3Slots);
-        assert_eq!(grant2.granting_delay, BasicSlotgrantGrantingDelay::DelayNOpportunities(1));
+        assert_eq!(
+            grant2.capacity_allocation,
+            BasicSlotgrantCapAlloc::Grant3Slots
+        );
+        assert_eq!(
+            grant2.granting_delay,
+            BasicSlotgrantGrantingDelay::DelayNOpportunities(1)
+        );
     }
 
-        #[test] 
+    #[test]
     fn test_dl_grant_and_ack_integration() {
         let mut sched = get_testing_slotter();
         let ts = TdmaTime::default();
-        let addr = TetraAddress { encrypted: false, ssi_type: SsiType::Issi, ssi: 1234 };
+        let addr = TetraAddress {
+            encrypted: false,
+            ssi_type: SsiType::Issi,
+            ssi: 1234,
+        };
         let pdu = BsChannelScheduler::dl_make_minimal_resource(&addr, None, false);
         let sdu = BitBuffer::new(0);
         sched.dl_enqueue_tma(ts.t, pdu, sdu);
@@ -1007,6 +1276,5 @@ mod tests {
         sched.dump_dl_queue();
 
         assert!(sched.dltx_queues[ts.t as usize - 1].len() == 1);
-
     }
 }

--- a/src/entities/umac/umac_bs.rs
+++ b/src/entities/umac/umac_bs.rs
@@ -12,12 +12,11 @@ use crate::common::tdma_time::TdmaTime;
 
 use crate::common::tetra_common::{Sap, Todo};
 use crate::common::tetra_entities::TetraEntity;
+use crate::config::stack_config::*;
+use crate::entities::TetraEntityTrait;
 use crate::entities::mle::fields::bs_service_details::BsServiceDetails;
 use crate::entities::mle::pdus::d_mle_sync::DMleSync;
 use crate::entities::mle::pdus::d_mle_sysinfo::DMleSysinfo;
-use crate::entities::TetraEntityTrait;
-use crate::saps::sapmsg::{SapMsg, SapMsgInner};
-use crate::config::stack_config::*;
 use crate::entities::umac::enums::broadcast_type::BroadcastType;
 use crate::entities::umac::enums::mac_pdu_type::MacPduType;
 use crate::entities::umac::enums::sysinfo_opt_field_flag::SysinfoOptFieldFlag;
@@ -34,23 +33,23 @@ use crate::entities::umac::pdus::mac_sync::MacSync;
 use crate::entities::umac::pdus::mac_sysinfo::MacSysinfo;
 use crate::entities::umac::pdus::mac_u_blck::MacUBlck;
 use crate::entities::umac::pdus::mac_u_signal::MacUSignal;
+use crate::entities::umac::subcomp::bs_sched::{BsChannelScheduler, PrecomputedUmacPdus};
 use crate::entities::umac::subcomp::event_labels::EventLabelStore;
 use crate::entities::umac::subcomp::fillbits::get_num_fill_bits;
-use crate::entities::umac::subcomp::bs_sched::{BsChannelScheduler, PrecomputedUmacPdus};
+use crate::saps::sapmsg::{SapMsg, SapMsgInner};
 use crate::{assert_warn, unimplemented_log};
 
 use super::subcomp::defrag::MacDefrag;
 
-/// Each tick, we submit a frame for TX (-> Lmac -> Phy). 
+/// Each tick, we submit a frame for TX (-> Lmac -> Phy).
 /// This constant determines how many timeslots in the future we submit for
-/// This indirectly controls the size of the TX buffer in the SDR. 
-const DLTX_SUBMIT_DELTA: usize = 4*4;
+/// This indirectly controls the size of the TX buffer in the SDR.
+const DLTX_SUBMIT_DELTA: usize = 4 * 4;
 
 pub struct UmacBs {
-
     self_component: TetraEntity,
     config: SharedConfig,
-    
+
     /// This MAC's endpoint ID, for addressing by the higher layers
     /// When using only a single base radio, we can set this to a fixed value
     endpoint_id: u32,
@@ -58,7 +57,7 @@ pub struct UmacBs {
     /// Subcomponents
     defrag: MacDefrag,
     event_label_store: EventLabelStore,
-    
+
     /// Contains UL/DL scheduling logic
     /// Access to this field is used only by testing code
     pub channel_scheduler: BsChannelScheduler,
@@ -67,11 +66,10 @@ pub struct UmacBs {
 
 impl UmacBs {
     pub fn new(config: SharedConfig) -> Self {
-
-        let mut ret = Self { 
+        let mut ret = Self {
             self_component: TetraEntity::Umac,
             config,
-            endpoint_id: 0, 
+            endpoint_id: 0,
             defrag: MacDefrag::new(),
             event_label_store: EventLabelStore::new(),
             channel_scheduler: BsChannelScheduler::new(),
@@ -81,7 +79,7 @@ impl UmacBs {
         if ret.config.config().stack_mode == StackMode::Bs {
             // Precompute various frequently transmitted messages
             ret.initialize_scheduler();
-        } 
+        }
 
         ret
     }
@@ -90,7 +88,6 @@ impl UmacBs {
     /// Precomputed PDUs are passed to scheduler
     /// Needs to be re-invoked if any network parameter changes
     pub fn initialize_scheduler(&mut self) {
-
         let c = self.config.config();
 
         // TODO FIXME make more/all parameters configurable
@@ -129,13 +126,13 @@ impl UmacBs {
             ms_txpwr_max_cell: 5,
             rxlev_access_min: 3,
             access_parameter: 7,
-            radio_dl_timeout: 3,
-            cck_id: Some(1), // TODO FIXME change to Some() when we enable encryption
-            hyperframe_number: None,
+            radio_dl_timeout: 15,
+            cck_id: None,
+            hyperframe_number: Some(0), // Updated dynamically in scheduler
             option_field: SysinfoOptFieldFlag::DefaultDefForAccCodeA,
             ts_common_frames: None,
             default_access_code: Some(def_access),
-            ext_services: None
+            ext_services: None,
         };
 
         let sysinfo2 = MacSysinfo {
@@ -154,7 +151,7 @@ impl UmacBs {
             option_field: SysinfoOptFieldFlag::ExtServicesBroadcast,
             ts_common_frames: None,
             default_access_code: None,
-            ext_services: Some(ext_services)
+            ext_services: Some(ext_services),
         };
 
         let mle_sysinfo_pdu = DMleSysinfo {
@@ -172,7 +169,7 @@ impl UmacBs {
                 sndcp_service: false,
                 aie_service: false,
                 advanced_link: false,
-            }
+            },
         };
 
         let mac_sync_pdu = MacSync {
@@ -189,19 +186,20 @@ impl UmacBs {
             mcc: c.net.mcc,
             mnc: c.net.mnc,
             neighbor_cell_broadcast: 2, // Broadcast supported, but enquiry not supported
-            cell_load_ca: 0, 
+            cell_load_ca: 0,
             late_entry_supported: true,
         };
 
         let precomps = PrecomputedUmacPdus {
             mac_sysinfo1: sysinfo1,
             mac_sysinfo2: sysinfo2,
-            mle_sysinfo: mle_sysinfo_pdu,        
+            mle_sysinfo: mle_sysinfo_pdu,
             mac_sync: mac_sync_pdu,
             mle_sync: mle_sync_pdu,
-        }; 
-        
-        self.channel_scheduler.set_scrambling_code(c.scrambling_code());
+        };
+
+        self.channel_scheduler
+            .set_scrambling_code(c.scrambling_code());
         self.channel_scheduler.set_precomputed_msgs(precomps);
     }
 
@@ -219,18 +217,21 @@ impl UmacBs {
 
     pub fn rx_tmv_unitdata_ind(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
         tracing::trace!("rx_tmv_unitdata_ind");
-        
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
-            
+
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
+
         match prim.logical_channel {
-            LogicalChannel::Stch | 
-            LogicalChannel::SchF| 
-            LogicalChannel::SchHu => {
+            LogicalChannel::Stch | LogicalChannel::SchF | LogicalChannel::SchHu => {
                 tracing::trace!("rx_tmv_unitdata_ind: {:?}", prim.logical_channel);
                 self.rx_tmv_sch(queue, message);
             }
             _ => {
-                panic!("rx_tmv_unitdata_ind: Unknown logical channel {:?}", prim.logical_channel);
+                panic!(
+                    "rx_tmv_unitdata_ind: Unknown logical channel {:?}",
+                    prim.logical_channel
+                );
             }
         }
     }
@@ -238,11 +239,13 @@ impl UmacBs {
     /// Receive signalling (SCH, or STCH / BNCH)
     pub fn rx_tmv_sch(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
         tracing::trace!("rx_tmv_sch");
-        
+
         // Iterate until no more messages left in mac block
         loop {
             // Extract info from inner block
-            let SapMsgInner::TmvUnitdataInd(prim) = &message.msg else { panic!() };
+            let SapMsgInner::TmvUnitdataInd(prim) = &message.msg else {
+                panic!()
+            };
             let Some(bits) = prim.pdu.peek_bits(3) else {
                 tracing::warn!("insufficient bits: {}", prim.pdu.dump_bin());
                 return;
@@ -252,8 +255,7 @@ impl UmacBs {
 
             // Clause 21.4.1; handling differs between SCH_HU and others
             match lchan {
-                LogicalChannel::SchF |
-                LogicalChannel::Stch => {
+                LogicalChannel::SchF | LogicalChannel::Stch => {
                     // First two bits are MAC PDU type
                     let Ok(pdu_type) = MacPduType::try_from(bits >> 1) else {
                         tracing::warn!("invalid pdu type: {}", bits >> 1);
@@ -296,7 +298,7 @@ impl UmacBs {
                     match pdu_type {
                         0 => self.rx_mac_access(queue, &mut message),
                         1 => self.rx_mac_end_hu(queue, &mut message),
-                        _ => panic!()
+                        _ => panic!(),
                     }
                 }
 
@@ -304,17 +306,13 @@ impl UmacBs {
                     tracing::warn!("unknown logical channel: {:?}", lchan);
                 }
             }
-            
-            
 
             // Check if end of message reached by re-borrowing inner
             // If start was not updated, we also consider it end of message
             // If 16 or more bits remain (len of null pdu), we continue parsing
             if let SapMsgInner::TmvUnitdataInd(prim) = &message.msg {
                 if prim.pdu.get_raw_start() != orig_start && prim.pdu.get_len() >= 16 {
-                    tracing::trace!(
-                        "orig {} now {}", orig_start, prim.pdu.get_raw_start()
-                    );
+                    tracing::trace!("orig {} now {}", orig_start, prim.pdu.get_raw_start());
                     tracing::trace!(
                         "rx_tmv_unitdata_ind_sch: Remaining {} bits: {:?}",
                         prim.pdu.get_len_remaining(),
@@ -332,10 +330,12 @@ impl UmacBs {
     // Will NOT advance pos but pass to underlying function
     fn rx_broadcast(&self, queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_broadcast");
-        
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.peek_bits(2).unwrap() == MacPduType::Broadcast.into_raw()); // MAC PDU type
-        
+
         let bits = prim.pdu.peek_bits_posoffset(2, 2).unwrap();
         let bcast_type = BroadcastType::try_from(bits).expect("invalid broadcast type");
 
@@ -344,28 +344,36 @@ impl UmacBs {
                 self.rx_access_define(queue, message);
             }
 
-            _ => { panic!(); }
+            _ => {
+                panic!();
+            }
         }
     }
 
     // Parses the sysinfo pdu
     fn rx_access_define(&self, _queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_access_define");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
-        
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
+
         let _pdu = match AccessDefine::from_bitbuf(&mut prim.pdu) {
             Ok(pdu) => {
                 tracing::debug!("<- {:?}", pdu);
                 pdu
             }
             Err(e) => {
-                tracing::warn!("Failed parsing AccessDefine: {:?} {}", e, prim.pdu.dump_bin());
+                tracing::warn!(
+                    "Failed parsing AccessDefine: {:?} {}",
+                    e,
+                    prim.pdu.dump_bin()
+                );
                 return;
             }
         };
 
         unimplemented!("rx_access_define");
-        
+
         // if pdu.hyperframe_number.is_some() && pdu.hyperframe_number.unwrap() != message.t_submit.h {
         //     // Send message to Phy about new hyperframe number
         //     let t = TdmaTime{
@@ -380,7 +388,7 @@ impl UmacBs {
         //         dest: TetraComponent::Lmac,
         //         t_submit: message.t_submit,
         //         msg: SapMsgInner::TmvConfigureReq(
-        //             TmvConfigureReq{ 
+        //             TmvConfigureReq{
         //                 time: Some(t),
         //                 ..Default::default()
         //             }
@@ -404,14 +412,15 @@ impl UmacBs {
         //         }
         //     )
         // };
-        
+
         // queue.push_back(m);
     }
 
     fn rx_mac_data(&mut self, queue: &mut MessageQueue, message: &mut SapMsg) {
-        
         tracing::trace!("rx_mac_data");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.get_pos() == 0); // We should be at the start of the MAC PDU
 
         let pdu = match MacData::from_bitbuf(&mut prim.pdu) {
@@ -427,55 +436,52 @@ impl UmacBs {
 
         if pdu.event_label.is_some() {
             tracing::warn!("event labels not implemented");
-        }   
+        }
 
-        // Compute len and extract flags        
+        // Compute len and extract flags
         let (mut pdu_len_bits, is_frag_start, second_half_stolen, is_null_pdu) = {
             if let Some(len_ind) = pdu.length_ind {
-
                 // We have a lenght ind, either clear length, a stolen slot indication, or a fragmentation start
                 match len_ind {
                     0b000000 => {
                         // Null PDU
-                        (   
-                            if pdu.event_label.is_some() { 23 } else { 37 }, 
-                            false, false, true
-                        ) 
+                        (
+                            if pdu.event_label.is_some() { 23 } else { 37 },
+                            false,
+                            false,
+                            true,
+                        )
                     }
 
                     0b000010..0b111000 => {
                         // tracing::trace!("rx_mac_data: length_ind {}", len_ind);
-                        (
-                            len_ind as usize * 8, 
-                            false, false, false
-                        )
+                        (len_ind as usize * 8, false, false, false)
                     }
                     0b111110 => {
                         // Second half slot stolen in STCH
-                        unimplemented_log!("rx_mac_data: SECOND HALF SLOT STOLEN IN STCH but signal not implemented");
-                        (
-                            prim.pdu.get_len(), 
-                            false, true, false
-                        )
+                        unimplemented_log!(
+                            "rx_mac_data: SECOND HALF SLOT STOLEN IN STCH but signal not implemented"
+                        );
+                        (prim.pdu.get_len(), false, true, false)
                     }
                     0b111111 => {
                         // Start of fragmentation
                         // tracing::trace!("rx_mac_data: frag_start");
-                        (
-                            prim.pdu.get_len(), 
-                            true, false, false
-                        )
+                        (prim.pdu.get_len(), true, false, false)
                     }
-                    _ => panic!("rx_mac_data: Invalid length_ind {}", len_ind)
+                    _ => panic!("rx_mac_data: Invalid length_ind {}", len_ind),
                 }
             } else {
-                
                 // We have a capacity request
-                tracing::trace!("rx_mac_data: cap_req {}", if pdu.frag_flag.unwrap() { "with frag_start" } else { "" });
-                (
-                    prim.pdu.get_len(), 
-                    pdu.frag_flag.unwrap(), false, false
-                )
+                tracing::trace!(
+                    "rx_mac_data: cap_req {}",
+                    if pdu.frag_flag.unwrap() {
+                        "with frag_start"
+                    } else {
+                        ""
+                    }
+                );
+                (prim.pdu.get_len(), pdu.frag_flag.unwrap(), false, false)
             }
         };
 
@@ -487,7 +493,7 @@ impl UmacBs {
 
         // Strip fill bits. Maintain original end to allow for later parsing of a second mac block
         tracing::trace!("rx_mac_data: {}", prim.pdu.dump_bin_full(true));
-        let num_fill_bits= {
+        let num_fill_bits = {
             if pdu.fill_bits {
                 get_num_fill_bits(&prim.pdu, pdu_len_bits, is_null_pdu)
             } else {
@@ -496,56 +502,63 @@ impl UmacBs {
         };
         pdu_len_bits -= num_fill_bits;
         let orig_end = prim.pdu.get_raw_end();
-        prim.pdu.set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
-        tracing::trace!("rx_mac_data: pdu: {} sdu: {} fb: {}: {}", pdu_len_bits, prim.pdu.get_len_remaining(), num_fill_bits, prim.pdu.dump_bin_full(true));
-        
-        
+        prim.pdu
+            .set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
+        tracing::trace!(
+            "rx_mac_data: pdu: {} sdu: {} fb: {}: {}",
+            pdu_len_bits,
+            prim.pdu.get_len_remaining(),
+            num_fill_bits,
+            prim.pdu.dump_bin_full(true)
+        );
+
         if is_null_pdu {
             // TODO not sure if there is scenarios in which we want to pass a null pdu to the LLC
             // tracing::warn!("rx_mac_data: Null PDU not passed to LLC");
             return;
         }
-        
+
         // Decrypt if needed
         if pdu.encrypted {
             unimplemented_log!("rx_mac_data: Encryption mode > 0");
             return;
-        } 
+        }
 
         // Handle reservation if present
         let ul_time = message.dltime.add_timeslots(-2);
         if let Some(res_req) = &pdu.reservation_req {
-
             tracing::error!("rx_mac_data: time {:?} ul {:?}", message.dltime, ul_time);
-            let grant = self.channel_scheduler.ul_process_cap_req(ul_time.t, pdu.addr, res_req);
+            let grant = self
+                .channel_scheduler
+                .ul_process_cap_req(ul_time.t, pdu.addr, res_req);
             if let Some(grant) = grant {
                 // Schedule grant
-                self.channel_scheduler.dl_enqueue_grant(ul_time.t, pdu.addr, grant);
+                self.channel_scheduler
+                    .dl_enqueue_grant(ul_time.t, pdu.addr, grant);
             } else {
-                tracing::warn!("rx_mac_data: No grant for reservation request {:?}", res_req);
+                tracing::warn!(
+                    "rx_mac_data: No grant for reservation request {:?}",
+                    res_req
+                );
             }
         };
 
-        
         tracing::debug!("rx_mac_data: {}", prim.pdu.dump_bin_full(true));
         if is_frag_start {
             // Fragmentation start, add to defragmenter
-            self.defrag.insert_first(&mut prim.pdu, ul_time, pdu.addr, None);
-
+            self.defrag
+                .insert_first(&mut prim.pdu, ul_time, pdu.addr, None);
         } else if second_half_stolen {
-
             // TODO FIXME maybe not elif here
             tracing::warn!("rx_mac_data: SECOND HALF SLOT STOLEN IN STCH but not implemented");
-
         } else {
-
             // Pass directly to LLC
             let sdu = {
                 // if prim.pdu.get_len_remaining() == 0 {
                 //     None // No more data in this block
                 // } else {
-                    // TODO FIXME should not copy here but take ownership
-                    // Copy inner part, without MAC header or fill bits
+                // TODO FIXME should not copy here but take ownership
+                // Copy inner part, without MAC header or fill bits
                 Some(BitBuffer::from_bitbuffer_pos(&prim.pdu))
                 // }
             };
@@ -560,27 +573,25 @@ impl UmacBs {
             }
 
             if sdu.is_some() {
-                // We have an SDU for the LLC, deliver it. 
+                // We have an SDU for the LLC, deliver it.
                 let m = SapMsg {
                     sap: Sap::TmaSap,
                     src: TetraEntity::Umac,
                     dest: TetraEntity::Llc,
                     dltime: message.dltime,
 
-                    msg: SapMsgInner::TmaUnitdataInd(
-                        TmaUnitdataInd {
-                            pdu: sdu,
-                            main_address: pdu.addr,
-                            scrambling_code: prim.scrambling_code,
-                            endpoint_id: 0, // TODO FIXME
-                            new_endpoint_id: None, // TODO FIXME
-                            css_endpoint_id: None, // TODO FIXME
-                            air_interface_encryption: pdu.encrypted as Todo,
-                            chan_change_response_req: false,
-                            chan_change_handle: None,
-                            chan_info: None
-                        }
-                    )
+                    msg: SapMsgInner::TmaUnitdataInd(TmaUnitdataInd {
+                        pdu: sdu,
+                        main_address: pdu.addr,
+                        scrambling_code: prim.scrambling_code,
+                        endpoint_id: 0,        // TODO FIXME
+                        new_endpoint_id: None, // TODO FIXME
+                        css_endpoint_id: None, // TODO FIXME
+                        air_interface_encryption: pdu.encrypted as Todo,
+                        chan_change_response_req: false,
+                        chan_change_handle: None,
+                        chan_info: None,
+                    }),
                 };
                 queue.push_back(m);
             } else {
@@ -588,43 +599,43 @@ impl UmacBs {
                 // For now, we don't deliver this. However, important data may need to be signalled upwards
                 tracing::warn!("rx_mac_data: empty PDU not passed to LLC");
             }
-        } 
-
+        }
 
         // Since this is not a null pdu, more MAC PDUs may follow
         // This allows parent function to continue parsing
         prim.pdu.set_raw_end(orig_end);
-        prim.pdu.set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
+        prim.pdu
+            .set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
         prim.pdu.set_raw_start(prim.pdu.get_raw_pos());
     }
 
     fn rx_mac_access(&mut self, queue: &mut MessageQueue, message: &mut SapMsg) {
-
         tracing::trace!("rx_mac_access");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.get_pos() == 0); // We should be at the start of the MAC PDU
 
+        // TESTING CODE FOR UL/DL SYNCHRONIZATION
+        // let addr = TetraAddress {
+        //     encrypted: false,
+        //     ssi: 0xff00ff,
+        //     ssi_type: SsiType::Issi,
+        // };
+        // let res = BsChannelScheduler::dl_make_minimal_resource(&addr, None, false);
+        // let mut buf = BitBuffer::new_autoexpand(32);
+        // let ts = message.t_submit;
+        // let ts_ul = message.t_submit.add_timeslots(-2);
+        // buf.write_bits(0xFFFF, 16);
+        // buf.write_bits(ts.t as u64, 8);
+        // buf.write_bits(ts.f as u64, 8);
+        // buf.write_bits(ts.m as u64, 8);
+        // buf.write_bits(ts.h as u64, 16);
+        // buf.write_bits(0xFFFF, 16);
+        // buf.seek(0);
+        // self.channel_scheduler.dl_enqueue_tma(ts_ul.t, res, buf);
 
-            // TESTING CODE FOR UL/DL SYNCHRONIZATION
-            // let addr = TetraAddress {
-            //     encrypted: false,
-            //     ssi: 0xff00ff,
-            //     ssi_type: SsiType::Issi,
-            // };
-            // let res = BsChannelScheduler::dl_make_minimal_resource(&addr, None, false);
-            // let mut buf = BitBuffer::new_autoexpand(32);
-            // let ts = message.t_submit;
-            // let ts_ul = message.t_submit.add_timeslots(-2);
-            // buf.write_bits(0xFFFF, 16);
-            // buf.write_bits(ts.t as u64, 8); 
-            // buf.write_bits(ts.f as u64, 8);
-            // buf.write_bits(ts.m as u64, 8);
-            // buf.write_bits(ts.h as u64, 16);
-            // buf.write_bits(0xFFFF, 16);
-            // buf.seek(0);
-            // self.channel_scheduler.dl_enqueue_tma(ts_ul.t, res, buf);
-
-            // return;
+        // return;
 
         let pdu = match MacAccess::from_bitbuf(&mut prim.pdu) {
             Ok(pdu) => {
@@ -636,7 +647,7 @@ impl UmacBs {
                 return;
             }
         };
-       
+
         // Resolve event label (if supplied)
         let addr = if let Some(label) = pdu.event_label {
             tracing::warn!("event labels not implemented");
@@ -649,9 +660,11 @@ impl UmacBs {
             }
         } else if let Some(addr) = pdu.addr {
             addr
-        } else { panic!() };
+        } else {
+            panic!()
+        };
 
-        // Compute len and extract flags        
+        // Compute len and extract flags
         let mut pdu_len_bits;
         if let Some(length_ind) = pdu.length_ind {
             if length_ind == 0 {
@@ -666,7 +679,7 @@ impl UmacBs {
             } else {
                 // Full length ind
                 pdu_len_bits = length_ind as usize * 8;
-            }            
+            }
         } else {
             // No length ind, we have capacity request. Fill slot.
             pdu_len_bits = prim.pdu.get_len();
@@ -674,7 +687,10 @@ impl UmacBs {
 
         // Strip fill bits. Maintain original end to allow for later parsing of a second mac block
         // tracing::trace!("rx_mac_access: {}", prim.pdu.dump_bin_full(true));
-        assert!(pdu_len_bits <= prim.pdu.get_len(), "MAC-ACCESS pdu longer than buf");
+        assert!(
+            pdu_len_bits <= prim.pdu.get_len(),
+            "MAC-ACCESS pdu longer than buf"
+        );
         let num_fill_bits = if pdu.fill_bits {
             get_num_fill_bits(&prim.pdu, pdu_len_bits, pdu.is_null_pdu())
         } else {
@@ -682,9 +698,16 @@ impl UmacBs {
         };
         pdu_len_bits -= num_fill_bits;
         let orig_end = prim.pdu.get_raw_end();
-        prim.pdu.set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
-        tracing::trace!("rx_mac_access: pdu: {} sdu: {} fb: {}: {}", pdu_len_bits, prim.pdu.get_len_remaining(), num_fill_bits, prim.pdu.dump_bin_full(true));
-        
+        prim.pdu
+            .set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
+        tracing::trace!(
+            "rx_mac_access: pdu: {} sdu: {} fb: {}: {}",
+            pdu_len_bits,
+            prim.pdu.get_len_remaining(),
+            num_fill_bits,
+            prim.pdu.dump_bin_full(true)
+        );
+
         if pdu.is_null_pdu() {
             // tracing::warn!("rx_mac_access: Null PDU not passed to LLC");
             return;
@@ -692,33 +715,37 @@ impl UmacBs {
 
         // Schedule acknowledgement of this message
         let ul_time = message.dltime.add_timeslots(-2);
-        self.channel_scheduler.dl_enqueue_random_access_ack(ul_time.t, addr);
-        
+        self.channel_scheduler
+            .dl_enqueue_random_access_ack(ul_time.t, addr);
+
         // Decrypt if needed
         if pdu.encrypted {
             unimplemented_log!("rx_mac_access: Encryption mode > 0");
             return;
-        } 
+        }
 
         // Handle reservation if present
         if let Some(res_req) = &pdu.reservation_req {
-            let grant = self.channel_scheduler.ul_process_cap_req(ul_time.t, addr, res_req);
+            let grant = self
+                .channel_scheduler
+                .ul_process_cap_req(ul_time.t, addr, res_req);
             if let Some(grant) = grant {
                 // Schedule grant
-                self.channel_scheduler.dl_enqueue_grant(ul_time.t, addr, grant);
+                self.channel_scheduler
+                    .dl_enqueue_grant(ul_time.t, addr, grant);
             } else {
-                tracing::warn!("rx_mac_access: No grant for reservation request {:?}", res_req);
+                tracing::warn!(
+                    "rx_mac_access: No grant for reservation request {:?}",
+                    res_req
+                );
             }
         };
-        
+
         // tracing::debug!("rx_mac_access: {}", prim.pdu.dump_bin_full(true));
         if pdu.is_frag_start() {
-
             // Fragmentation start, add to defragmenter
             self.defrag.insert_first(&mut prim.pdu, ul_time, addr, None);
-
         } else {
-
             // Pass directly to LLC
             if prim.pdu.get_len_remaining() == 0 {
                 // Either this is a null pdu or we are at the end of the block
@@ -726,7 +753,7 @@ impl UmacBs {
                 tracing::warn!("rx_mac_access: empty PDU not passed to LLC");
                 return;
             };
-            
+
             // Pass directly to LLC
             let sdu = {
                 if prim.pdu.get_len_remaining() == 0 {
@@ -736,29 +763,27 @@ impl UmacBs {
                     Some(BitBuffer::from_bitbuffer_pos(&prim.pdu))
                 }
             };
-            
+
             if sdu.is_some() {
-                // We have an SDU for the LLC, deliver it. 
+                // We have an SDU for the LLC, deliver it.
                 let m = SapMsg {
                     sap: Sap::TmaSap,
                     src: TetraEntity::Umac,
                     dest: TetraEntity::Llc,
                     dltime: message.dltime,
 
-                    msg: SapMsgInner::TmaUnitdataInd(
-                        TmaUnitdataInd {
-                            pdu: sdu,
-                            main_address: addr,
-                            scrambling_code: prim.scrambling_code,
-                            endpoint_id: 0, // TODO FIXME
-                            new_endpoint_id: None, // TODO FIXME
-                            css_endpoint_id: None, // TODO FIXME
-                            air_interface_encryption: pdu.encrypted as Todo,
-                            chan_change_response_req: false,
-                            chan_change_handle: None,
-                            chan_info: None
-                        }
-                    )
+                    msg: SapMsgInner::TmaUnitdataInd(TmaUnitdataInd {
+                        pdu: sdu,
+                        main_address: addr,
+                        scrambling_code: prim.scrambling_code,
+                        endpoint_id: 0,        // TODO FIXME
+                        new_endpoint_id: None, // TODO FIXME
+                        css_endpoint_id: None, // TODO FIXME
+                        air_interface_encryption: pdu.encrypted as Todo,
+                        chan_change_response_req: false,
+                        chan_change_handle: None,
+                        chan_info: None,
+                    }),
                 };
                 queue.push_back(m);
             } else {
@@ -771,16 +796,18 @@ impl UmacBs {
         // Since this is not a null pdu, more MAC PDUs may follow
         // This allows parent function to continue parsing
         prim.pdu.set_raw_end(orig_end);
-        prim.pdu.set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
+        prim.pdu
+            .set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
         prim.pdu.set_raw_start(prim.pdu.get_raw_pos());
     }
 
     fn rx_mac_frag_ul(&mut self, _queue: &mut MessageQueue, message: &mut SapMsg) {
-
         tracing::trace!("rx_mac_frag_ul");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.get_pos() == 0); // We should be at the start of the MAC PDU
-        
+
         // Parse header and optional ChanAlloc
         let pdu = match MacFragUl::from_bitbuf(&mut prim.pdu) {
             Ok(pdu) => {
@@ -795,7 +822,7 @@ impl UmacBs {
 
         // Strip fill bits. This message is known to fill the slot.
         let mut pdu_len_bits = prim.pdu.get_len();
-        let num_fill_bits= {
+        let num_fill_bits = {
             if pdu.fill_bits {
                 get_num_fill_bits(&prim.pdu, pdu_len_bits, false)
             } else {
@@ -803,8 +830,13 @@ impl UmacBs {
             }
         };
         pdu_len_bits -= num_fill_bits;
-        prim.pdu.set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
-        tracing::debug!("rx_mac_frag_ul: pdu_len_bits: {} fill_bits: {}", pdu_len_bits, num_fill_bits);
+        prim.pdu
+            .set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
+        tracing::debug!(
+            "rx_mac_frag_ul: pdu_len_bits: {} fill_bits: {}",
+            pdu_len_bits,
+            num_fill_bits
+        );
 
         // Decrypt if needed
         let ul_time = message.dltime.add_timeslots(-2);
@@ -819,7 +851,9 @@ impl UmacBs {
 
     fn rx_mac_end_ul(&mut self, queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_mac_end_ul");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.get_pos() == 0); // We should be at the start of the MAC PDU
 
         // Parse header and optional ChanAlloc
@@ -837,7 +871,7 @@ impl UmacBs {
         // Will have either length_ind or reservation_req, never none or both
         let mut pdu_len_bits = if let Some(length_ind) = pdu.length_ind {
             length_ind as usize * 8
-        } else  {
+        } else {
             // No length ind, we have capacity request. Fill slot.
             prim.pdu.get_len()
         };
@@ -852,8 +886,15 @@ impl UmacBs {
         };
         pdu_len_bits -= num_fill_bits;
         let orig_end = prim.pdu.get_raw_end();
-        prim.pdu.set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
-        tracing::trace!("rx_mac_end_ul: pdu: {} sdu: {} fb: {}: {}", pdu_len_bits, prim.pdu.get_len_remaining(), num_fill_bits, prim.pdu.dump_bin_full(true));
+        prim.pdu
+            .set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
+        tracing::trace!(
+            "rx_mac_end_ul: pdu: {} sdu: {} fb: {}: {}",
+            pdu_len_bits,
+            prim.pdu.get_len_remaining(),
+            num_fill_bits,
+            prim.pdu.dump_bin_full(true)
+        );
 
         // Decrypt if needed
         let ul_time = message.dltime.add_timeslots(-2);
@@ -873,12 +914,18 @@ impl UmacBs {
 
         // Handle reservation if present
         if let Some(res_req) = &pdu.reservation_req {
-            let grant = self.channel_scheduler.ul_process_cap_req(ul_time.t, defragbuf.addr, res_req);
+            let grant =
+                self.channel_scheduler
+                    .ul_process_cap_req(ul_time.t, defragbuf.addr, res_req);
             if let Some(grant) = grant {
                 // Schedule grant
-                self.channel_scheduler.dl_enqueue_grant(ul_time.t, defragbuf.addr, grant);
+                self.channel_scheduler
+                    .dl_enqueue_grant(ul_time.t, defragbuf.addr, grant);
             } else {
-                tracing::warn!("rx_mac_end_ul: No grant for reservation request {:?}", res_req);
+                tracing::warn!(
+                    "rx_mac_end_ul: No grant for reservation request {:?}",
+                    res_req
+                );
             }
         };
 
@@ -891,33 +938,34 @@ impl UmacBs {
             dest: TetraEntity::Llc,
             dltime: message.dltime,
 
-            msg: SapMsgInner::TmaUnitdataInd(
-                TmaUnitdataInd {
-                    pdu: Some(defragbuf.buffer),
-                    main_address: defragbuf.addr,
-                    scrambling_code: prim.scrambling_code,
-                    endpoint_id: 0, // TODO FIXME
-                    new_endpoint_id: None, // TODO FIXME
-                    css_endpoint_id: None, // TODO FIXME
-                    air_interface_encryption: 0, // TODO FIXME implement
-                    chan_change_response_req: false,
-                    chan_change_handle: None,
-                    chan_info: None
-                }
-            )
+            msg: SapMsgInner::TmaUnitdataInd(TmaUnitdataInd {
+                pdu: Some(defragbuf.buffer),
+                main_address: defragbuf.addr,
+                scrambling_code: prim.scrambling_code,
+                endpoint_id: 0,              // TODO FIXME
+                new_endpoint_id: None,       // TODO FIXME
+                css_endpoint_id: None,       // TODO FIXME
+                air_interface_encryption: 0, // TODO FIXME implement
+                chan_change_response_req: false,
+                chan_change_handle: None,
+                chan_info: None,
+            }),
         };
         queue.push_back(m);
 
         // Since this is not a null pdu, more MAC PDUs may follow
         // This allows parent function to continue parsing
         prim.pdu.set_raw_end(orig_end);
-        prim.pdu.set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
+        prim.pdu
+            .set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
         prim.pdu.set_raw_start(prim.pdu.get_raw_pos());
     }
 
     fn rx_mac_end_hu(&mut self, queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_mac_end_hu");
-        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmvUnitdataInd(prim) = &mut message.msg else {
+            panic!()
+        };
         assert!(prim.pdu.get_pos() == 0); // We should be at the start of the MAC PDU
 
         // Parse header and optional ChanAlloc
@@ -945,12 +993,11 @@ impl UmacBs {
             } else {
                 len
             }
-        } else  {
+        } else {
             // No length ind, we have capacity request. Fill slot.
             prim.pdu.get_len()
         };
         // Max length is buf length
-        
 
         // Strip fill bits if any
         let num_fill_bits = {
@@ -962,10 +1009,17 @@ impl UmacBs {
         };
         pdu_len_bits -= num_fill_bits;
         let orig_end = prim.pdu.get_raw_end();
-        prim.pdu.set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
+        prim.pdu
+            .set_raw_end(prim.pdu.get_raw_start() + pdu_len_bits);
         // tracing::error!("rx_mac_end_hu: orig_end {} raw_start {} num_fill_bits {} curr_pos {}", orig_end, prim.pdu.get_raw_start(), num_fill_bits, prim.pdu.get_raw_pos());
         // set to trace
-        tracing::trace!("rx_mac_end_hu: pdu: {} sdu: {} fb: {}: {}", pdu_len_bits, prim.pdu.get_len_remaining(), num_fill_bits, prim.pdu.dump_bin_full(true));
+        tracing::trace!(
+            "rx_mac_end_hu: pdu: {} sdu: {} fb: {}: {}",
+            pdu_len_bits,
+            prim.pdu.get_len_remaining(),
+            num_fill_bits,
+            prim.pdu.dump_bin_full(true)
+        );
 
         // Decrypt if needed
         let ul_time = message.dltime.add_timeslots(-2);
@@ -985,12 +1039,18 @@ impl UmacBs {
 
         // Handle reservation if present
         if let Some(res_req) = &pdu.reservation_req {
-            let grant = self.channel_scheduler.ul_process_cap_req(ul_time.t, defragbuf.addr, res_req);
+            let grant =
+                self.channel_scheduler
+                    .ul_process_cap_req(ul_time.t, defragbuf.addr, res_req);
             if let Some(grant) = grant {
                 // Schedule grant
-                self.channel_scheduler.dl_enqueue_grant(ul_time.t, defragbuf.addr, grant);
+                self.channel_scheduler
+                    .dl_enqueue_grant(ul_time.t, defragbuf.addr, grant);
             } else {
-                tracing::warn!("rx_mac_end_hu: No grant for reservation request {:?}", res_req);
+                tracing::warn!(
+                    "rx_mac_end_hu: No grant for reservation request {:?}",
+                    res_req
+                );
             }
         };
 
@@ -1003,20 +1063,18 @@ impl UmacBs {
             dest: TetraEntity::Llc,
             dltime: message.dltime,
 
-            msg: SapMsgInner::TmaUnitdataInd(
-                TmaUnitdataInd {
-                    pdu: Some(defragbuf.buffer),
-                    main_address: defragbuf.addr,
-                    scrambling_code: prim.scrambling_code,
-                    endpoint_id: 0, // TODO FIXME
-                    new_endpoint_id: None, // TODO FIXME
-                    css_endpoint_id: None, // TODO FIXME
-                    air_interface_encryption: 0, // TODO FIXME implement
-                    chan_change_response_req: false,
-                    chan_change_handle: None,
-                    chan_info: None
-                }
-            )
+            msg: SapMsgInner::TmaUnitdataInd(TmaUnitdataInd {
+                pdu: Some(defragbuf.buffer),
+                main_address: defragbuf.addr,
+                scrambling_code: prim.scrambling_code,
+                endpoint_id: 0,              // TODO FIXME
+                new_endpoint_id: None,       // TODO FIXME
+                css_endpoint_id: None,       // TODO FIXME
+                air_interface_encryption: 0, // TODO FIXME implement
+                chan_change_response_req: false,
+                chan_change_handle: None,
+                chan_info: None,
+            }),
         };
         queue.push_back(m);
 
@@ -1024,18 +1082,20 @@ impl UmacBs {
         // This allows parent function to continue parsing
         // tracing::trace!("rx_mac_end_hu: orig_end {} raw_start {} num_fill_bits {} curr_pos {}", orig_end, prim.pdu.get_raw_start(), num_fill_bits, prim.pdu.get_raw_pos());
         prim.pdu.set_raw_end(orig_end);
-        prim.pdu.set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
+        prim.pdu
+            .set_raw_pos(prim.pdu.get_raw_start() + pdu_len_bits + num_fill_bits);
         prim.pdu.set_raw_start(prim.pdu.get_raw_pos());
     }
 
-    
     /// TMD-SAP MAC-U-SIGNAL
     fn rx_ul_mac_u_signal(&self, _queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_ul_mac_u_signal");
         // let SapMsgInner::TmvUnitdataInd(inner) = &mut message.msg else {panic!()};
-        
+
         // Extract sdu and parse pdu
-        let SapMsgInner::TmaUnitdataReq(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmaUnitdataReq(prim) = &mut message.msg else {
+            panic!()
+        };
 
         let _pdu = match MacUSignal::from_bitbuf(&mut prim.pdu) {
             Ok(pdu) => {
@@ -1047,16 +1107,18 @@ impl UmacBs {
                 return;
             }
         };
-        
-        unimplemented!();   
+
+        unimplemented!();
     }
 
     /// TMA-SAP MAC-U-BLCK
     fn rx_ul_mac_u_blck(&self, _queue: &mut MessageQueue, message: &mut SapMsg) {
         tracing::trace!("rx_ul_mac_u_blck");
-        
+
         // Extract sdu and parse pdu
-        let SapMsgInner::TmaUnitdataReq(prim) = &mut message.msg else {panic!()};
+        let SapMsgInner::TmaUnitdataReq(prim) = &mut message.msg else {
+            panic!()
+        };
 
         let _pdu = match MacUBlck::from_bitbuf(&mut prim.pdu) {
             Ok(pdu) => {
@@ -1070,24 +1132,26 @@ impl UmacBs {
         };
 
         // Handle reservation if present
-        // TODO implement slightly different handling since enum is not the same. 
+        // TODO implement slightly different handling since enum is not the same.
         unimplemented!();
     }
 
     fn rx_ul_tma_unitdata_req(&mut self, _queue: &mut MessageQueue, message: SapMsg) {
         tracing::trace!("rx_ul_tma_unitdata_req");
-        
+
         // Extract sdu
-        let SapMsgInner::TmaUnitdataReq(prim) = message.msg else {panic!()};
+        let SapMsgInner::TmaUnitdataReq(prim) = message.msg else {
+            panic!()
+        };
         let sdu = prim.pdu;
-        
+
         // Build MAC-RESOURCE optimistically (as if it would always fit in one slot)
         let mut pdu = MacResource {
             fill_bits: false, // Updated later
             pos_of_grant: 0,
-            encryption_mode: 0, 
+            encryption_mode: 0,
             random_access_flag: true, // TODO FIXME we just always ack a random access
-            length_ind: 0, // Updated later
+            length_ind: 0,            // Updated later
             addr: Some(prim.main_address),
             event_label: None,
             usage_marker: None,
@@ -1108,7 +1172,7 @@ impl UmacBs {
             SapMsgInner::TmaUnitdataReq(_) => {
                 self.rx_ul_tma_unitdata_req(queue, message);
             }
-            _ => panic!()
+            _ => panic!(),
         }
     }
 
@@ -1119,7 +1183,9 @@ impl UmacBs {
 
     fn rx_tlmc_configure_req(&mut self, _queue: &mut MessageQueue, message: SapMsg) {
         tracing::trace!("rx_tlmc_configure_req");
-        let SapMsgInner::TlmcConfigureReq(_prim) = &message.msg else {panic!()};
+        let SapMsgInner::TlmcConfigureReq(_prim) = &message.msg else {
+            panic!()
+        };
         unimplemented!();
     }
 
@@ -1136,10 +1202,7 @@ impl UmacBs {
     }
 }
 
-
-
 impl TetraEntityTrait for UmacBs {
-
     fn entity(&self) -> TetraEntity {
         TetraEntity::Umac
     }
@@ -1149,7 +1212,6 @@ impl TetraEntityTrait for UmacBs {
     }
 
     fn rx_prim(&mut self, queue: &mut MessageQueue, message: SapMsg) {
-        
         tracing::debug!("rx_prim: {:?}", message);
         match message.sap {
             Sap::TmvSap => {
@@ -1175,11 +1237,17 @@ impl TetraEntityTrait for UmacBs {
     }
 
     fn tick_start(&mut self, queue: &mut MessageQueue, ts: Option<TdmaTime>) {
-
         if self.config.config().stack_mode == StackMode::Bs {
-            
             let Some(ts) = ts else { panic!() };
-            if self.channel_scheduler.cur_ts != ts && self.channel_scheduler.cur_ts == (TdmaTime {t: 0, f: 0, m: 0, h: 0}) {
+            if self.channel_scheduler.cur_ts != ts
+                && self.channel_scheduler.cur_ts
+                    == (TdmaTime {
+                        t: 0,
+                        f: 0,
+                        m: 0,
+                        h: 0,
+                    })
+            {
                 // Upon start of the system, we need to set the dl time for the channel scheduler
                 self.channel_scheduler.set_dl_time(ts);
             } else {
@@ -1189,7 +1257,7 @@ impl TetraEntityTrait for UmacBs {
 
             // Collect/construct traffic that should be sent down to the LMAC
             let elem = self.channel_scheduler.finalize_ts_for_tick();
-            let s = SapMsg{
+            let s = SapMsg {
                 sap: Sap::TmvSap,
                 src: self.self_component,
                 dest: TetraEntity::Lmac,


### PR DESCRIPTION
- Set radio_dl_timeout to maximum (15) to prevent T307 timer expiration
- Use BSCH (SDB burst) only on frame 18, SCH/HD (NDB burst) on frames 1-17
- Update hyperframe number dynamically in SYSINFO broadcasts
- Use hyperframe_number consistently instead of cck_id in SYSINFO1

Motorola radios were entering a "connected, no service" loop every ~4 seconds
due to stricter T307 timeout handling.