### PR TITLE
Feature - Added Adaptive Jitter Buffer for Brew Ingress audio

### DIFF
--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -74,6 +74,8 @@ fn build_bs_stack(cfg: &mut SharedConfig) -> MessageRouter {
             issi: brew_cfg.issi,
             groups: brew_cfg.groups,
             reconnect_delay: Duration::from_secs(brew_cfg.reconnect_delay_secs),
+            jitter_buffer: brew_cfg.jitter_buffer,
+            jitter_log: brew_cfg.jitter_log,
         };
         let brew_entity = BrewEntity::new(cfg.clone(), brew_config);
         router.register_entity(Box::new(brew_entity));

--- a/crates/tetra-config/src/stack_config_brew.rs
+++ b/crates/tetra-config/src/stack_config_brew.rs
@@ -22,6 +22,10 @@ pub struct CfgBrew {
     pub groups: Vec<u32>,
     /// Reconnection delay in seconds
     pub reconnect_delay_secs: u64,
+    /// Enable inbound downlink jitter buffer for Brew voice
+    pub jitter_buffer: bool,
+    /// Emit adaptive jitter telemetry in logs
+    pub jitter_log: bool,
 }
 
 #[derive(Default, Deserialize)]
@@ -44,6 +48,12 @@ pub struct CfgBrewDto {
     /// Reconnection delay in seconds
     #[serde(default = "default_brew_reconnect_delay")]
     pub reconnect_delay_secs: u64,
+    /// Enable inbound downlink jitter buffer for Brew voice
+    #[serde(default = "default_brew_jitter_buffer")]
+    pub jitter_buffer: bool,
+    /// Emit adaptive jitter telemetry in logs
+    #[serde(default)]
+    pub jitter_log: bool,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -57,6 +67,10 @@ fn default_brew_reconnect_delay() -> u64 {
     15
 }
 
+fn default_brew_jitter_buffer() -> bool {
+    true
+}
+
 /// Convert a CfgBrewDto (from TOML) into a CfgBrew (used in the stack config)
 pub fn apply_brew_patch(src: CfgBrewDto) -> CfgBrew {
     CfgBrew {
@@ -68,5 +82,7 @@ pub fn apply_brew_patch(src: CfgBrewDto) -> CfgBrew {
         issi: src.issi,
         groups: src.groups,
         reconnect_delay_secs: src.reconnect_delay_secs,
+        jitter_buffer: src.jitter_buffer,
+        jitter_log: src.jitter_log,
     }
 }

--- a/crates/tetra-entities/src/brew/worker.rs
+++ b/crates/tetra-entities/src/brew/worker.rs
@@ -92,6 +92,10 @@ pub struct BrewConfig {
     pub groups: Vec<u32>,
     /// Reconnection delay
     pub reconnect_delay: Duration,
+    /// Enable inbound downlink jitter buffer for Brew voice
+    pub jitter_buffer: bool,
+    /// Emit adaptive jitter telemetry in logs
+    pub jitter_log: bool,
 }
 
 // ─── TLS helper ──────────────────────────────────────────────────

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -173,3 +173,11 @@ voice_service = true  # Not yet implemented but may be needed to keep certain MS
 
 # Reconnection delay (seconds)
 # reconnect_delay_secs = 15
+
+# Optional: enable inbound Brew jitter buffer (recommended for variable-latency links).
+# Set false to use immediate frame injection (legacy behavior).
+# jitter_buffer = true
+
+# Optional: log adaptive jitter buffer playout telemetry for inbound Brew calls.
+# This is written through normal tracing (typically visible in debug_log file).
+# jitter_log = false


### PR DESCRIPTION
Summary
This PR adds an adaptive inbound jitter buffer for Brew (GROUP_VOICE) downlink audio in BlueStation, to smooth variable-latency packet arrival from TCP/WebSocket transport before injecting frames into TETRA playout.

What changed
Added a per-call DL jitter buffer in Brew entity, keyed by Brew call UUID.

Added adaptive target depth logic based on observed inter-arrival variance and underrun history.

Playout now drains buffered frames at traffic opportunities instead of immediate frame injection.

Added config toggles:
brew.jitter_buffer (default: true) to enable/disable jitter buffering.
brew.jitter_log (default: false) to enable jitter telemetry logging.

Added corresponding config documentation in [config.toml]
Wired config through startup/runtime Brew config structures.

Behavior
When jitter_buffer = true:

Frames are queued per active Brew call.
Buffer target adapts within bounded limits to reduce underruns under network jitter.
One frame is played out per eligible traffic playout window.

When jitter_buffer = false:

Legacy behavior is preserved (immediate injection of received frames).
Logging
Jitter telemetry is emitted only when jitter_log = true (to avoid normal log spam).
Logs include playout metadata like call UUID, frame age, and current target depth.

Why
Brew audio arrives over TCP/WebSocket, where burstiness and variable delay are common. Immediate injection can cause unstable playout; adaptive buffering improves continuity while limiting added latency.