### PR TITLE
Feature: Adaptive JitterBuffer for Brew Originated Calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "bluestation-bs"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "clap",
  "ctrlc",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "net-tnmm-test"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "clap",
  "tetra-config",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "net-tnmm-test-quic"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "quinn",
  "rcgen",
@@ -910,7 +910,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "pdu-tool"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "clap",
  "tetra-config",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-config"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "serde",
  "tetra-core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-core"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "const_format",
  "git-version",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-entities"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "as-any",
  "bitcode",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-pdus"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "tetra-config",
  "tetra-core",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-saps"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "tetra-core",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.3"
 edition = "2024"
 authors = ["Wouter Bokslag / Midnight Blue"]
 license = "MIT"

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -74,8 +74,7 @@ fn build_bs_stack(cfg: &mut SharedConfig) -> MessageRouter {
             issi: brew_cfg.issi,
             groups: brew_cfg.groups,
             reconnect_delay: Duration::from_secs(brew_cfg.reconnect_delay_secs),
-            jitter_buffer: brew_cfg.jitter_buffer,
-            jitter_log: brew_cfg.jitter_log,
+            jitter_initial_latency_frames: brew_cfg.jitter_initial_latency_frames,
         };
         let brew_entity = BrewEntity::new(cfg.clone(), brew_config);
         router.register_entity(Box::new(brew_entity));

--- a/crates/tetra-config/src/stack_config_brew.rs
+++ b/crates/tetra-config/src/stack_config_brew.rs
@@ -22,10 +22,8 @@ pub struct CfgBrew {
     pub groups: Vec<u32>,
     /// Reconnection delay in seconds
     pub reconnect_delay_secs: u64,
-    /// Enable inbound downlink jitter buffer for Brew voice
-    pub jitter_buffer: bool,
-    /// Emit adaptive jitter telemetry in logs
-    pub jitter_log: bool,
+    /// Extra initial jitter playout delay in frames (added on top of adaptive baseline)
+    pub jitter_initial_latency_frames: u8,
 }
 
 #[derive(Default, Deserialize)]
@@ -48,12 +46,9 @@ pub struct CfgBrewDto {
     /// Reconnection delay in seconds
     #[serde(default = "default_brew_reconnect_delay")]
     pub reconnect_delay_secs: u64,
-    /// Enable inbound downlink jitter buffer for Brew voice
-    #[serde(default = "default_brew_jitter_buffer")]
-    pub jitter_buffer: bool,
-    /// Emit adaptive jitter telemetry in logs
+    /// Extra initial jitter playout delay in frames (added on top of adaptive baseline)
     #[serde(default)]
-    pub jitter_log: bool,
+    pub jitter_initial_latency_frames: u8,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -67,10 +62,6 @@ fn default_brew_reconnect_delay() -> u64 {
     15
 }
 
-fn default_brew_jitter_buffer() -> bool {
-    true
-}
-
 /// Convert a CfgBrewDto (from TOML) into a CfgBrew (used in the stack config)
 pub fn apply_brew_patch(src: CfgBrewDto) -> CfgBrew {
     CfgBrew {
@@ -82,7 +73,6 @@ pub fn apply_brew_patch(src: CfgBrewDto) -> CfgBrew {
         issi: src.issi,
         groups: src.groups,
         reconnect_delay_secs: src.reconnect_delay_secs,
-        jitter_buffer: src.jitter_buffer,
-        jitter_log: src.jitter_log,
+        jitter_initial_latency_frames: src.jitter_initial_latency_frames,
     }
 }

--- a/crates/tetra-entities/src/brew/worker.rs
+++ b/crates/tetra-entities/src/brew/worker.rs
@@ -92,10 +92,8 @@ pub struct BrewConfig {
     pub groups: Vec<u32>,
     /// Reconnection delay
     pub reconnect_delay: Duration,
-    /// Enable inbound downlink jitter buffer for Brew voice
-    pub jitter_buffer: bool,
-    /// Emit adaptive jitter telemetry in logs
-    pub jitter_log: bool,
+    /// Extra initial jitter playout delay in frames (added on top of adaptive baseline)
+    pub jitter_initial_latency_frames: u8,
 }
 
 // ─── TLS helper ──────────────────────────────────────────────────

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -174,10 +174,6 @@ voice_service = true  # Not yet implemented but may be needed to keep certain MS
 # Reconnection delay (seconds)
 # reconnect_delay_secs = 15
 
-# Optional: enable inbound Brew jitter buffer (recommended for variable-latency links).
-# Set false to use immediate frame injection (legacy behavior).
-# jitter_buffer = true
-
-# Optional: log adaptive jitter buffer playout telemetry for inbound Brew calls.
-# This is written through normal tracing (typically visible in debug_log file).
-# jitter_log = false
+# Optional: additional initial latency compensation in frames for inbound Brew jitter playout.
+# Adaptive jitter buffering is always enabled; this adds fixed startup delay if needed.
+# jitter_initial_latency_frames = 0


### PR DESCRIPTION
Brew Adaptive Jitter Buffer Refinement + v0.4.3

Summary
This PR refines the Brew inbound adaptive jitter buffer implementation and prepares a version bump to 0.4.3.

The jitter buffer is now always active for Brew downlink voice with a simplified config model:

removed enable/logging feature toggles
added one startup compensation setting
kept detailed telemetry in global TRACE
added warning logs when jitter conditions become unacceptable

What Changed:
1. Always-on adaptive Brew jitter buffering
Removed conditional enable/disable paths.
Inbound Brew downlink voice frames are always queued per-call before playout.
Per-call buffers are keyed by Brew call UUID and cleaned up on call end/disconnect.

2. Config simplification: initial latency compensation
Removed:
jitter_buffer
jitter_log
Added:
jitter_initial_latency_frames (default: 0)

Behavior:

Adaptive jitter buffering is always enabled.
jitter_initial_latency_frames adds a fixed startup playout offset on top of adaptive baseline.
0 = no added fixed startup delay beyond adaptive baseline.

3. Adaptive target behavior (retained + integrated)
Preserved adaptive logic:
EWMA-based arrival deviation tracking
target depth adaptation from observed variance
underrun boost and gradual recovery
bounded target depth
Startup compensation now feeds into target computation.

4. Logging behavior update
Detailed playout telemetry remains available in global TRACE (trace!), including:
UUID
timeslot
frame sequence
frame age
adaptive target depth
Added warn! jitter health alerts for poor conditions (e.g. elevated target depth / underruns), with per-call rate limiting to avoid spam.

5. Config/runtime wiring updates
Updated to remove old flags and carry the new field through:

CfgBrew / CfgBrewDto
runtime BrewConfig
bluestation-bs startup mapping

6. Example config update
Replaced old jitter flag comments with:
jitter_initial_latency_frames = 0
Documentation now reflects always-on adaptive jitter behavior.

7. Version bump and lockfile refresh
Workspace version bumped to 0.4.3 in [Cargo.toml]
[Cargo.lock] refreshed accordingly.