### PR TITLE
Fix CMCE floor-control signaling and LLC framing for group calls

### DIFF
--- a/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
+++ b/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
@@ -311,8 +311,9 @@ impl CircuitMgr {
                 if let Some(circuit) = circuit {
                     let age = circuit.ts_created.age(dltime);
 
-                    // Send D-SETUP for first 4 frames after circuit creation
-                    if age < 4 * 4 {
+                    // Send D-SETUP for the initial frame + 1 backup frame after circuit creation.
+                    // Matches ETSI Annex D Figure D.2: 1 initial + 1 back-up on MCCH.
+                    if age < 1 * 4 {
                         tasks
                             .get_or_insert_with(Vec::new)
                             .push(CircuitMgrCmd::SendDSetup(circuit.call_id, circuit.usage, circuit.ts));

--- a/crates/tetra-entities/src/lmac/lmac_bs.rs
+++ b/crates/tetra-entities/src/lmac/lmac_bs.rs
@@ -292,11 +292,14 @@ impl LmacBs {
         }
     }
 
-    // fn rx_tmv_configure_req(&mut self, _queue: &mut MessageQueue, mut message: SapMsg) {
-    //     tracing::trace!("rx_tmv_configure_req");
-    //     let SapMsgInner::TmvConfigureReq(_prim) = &mut message.msg else {panic!()};
-    //     unimplemented_log!("rx_tmv_configure_req");
-    // }
+    fn rx_tmv_configure_req(&mut self, _queue: &mut MessageQueue, message: SapMsg) {
+        let SapMsgInner::TmvConfigureReq(prim) = &message.msg else {
+            panic!()
+        };
+        if let Some(stolen) = prim.second_half_stolen {
+            self.second_block_stolen = stolen;
+        }
+    }
 
     /// Request from Umac to transmit a message
     fn rx_tmv_unitdata_req_slot(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
@@ -382,9 +385,9 @@ impl LmacBs {
         tracing::trace!("rx_tmv_prim");
 
         match message.msg {
-            // SapMsgInner::TmvConfigureReq(_) => {
-            //     self.rx_tmv_configure_req(queue, message);
-            // }
+            SapMsgInner::TmvConfigureReq(_) => {
+                self.rx_tmv_configure_req(queue, message);
+            }
             SapMsgInner::TmvUnitdataReq(_) => {
                 self.rx_tmv_unitdata_req_slot(queue, message);
             }

--- a/crates/tetra-pdus/src/cmce/pdus/d_call_restore.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_call_restore.rs
@@ -16,7 +16,7 @@ pub struct DCallRestore {
     /// Type1, 2 bits, Transmission grant
     pub transmission_grant: u8,
     /// Type1, 1 bits, Transmission request permission
-    /// Set to true to signal MSes they are allowed to send a U-TX DEMAND
+    /// ETSI 14.8.43: 0 = allowed to request transmission, 1 = not allowed.
     pub transmission_request_permission: bool,
     /// Type1, 1 bits, Reset call time-out timer (T310)
     pub reset_call_time_out_timer_t310_: bool,

--- a/crates/tetra-pdus/src/cmce/pdus/d_tx_ceased.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_tx_ceased.rs
@@ -14,7 +14,7 @@ pub struct DTxCeased {
     /// Type1, 14 bits, Call identifier
     pub call_identifier: u16,
     /// Type1, 1 bits, Transmission request permission
-    /// Set to true to signal MSes they are allowed to send a U-TX DEMAND
+    /// ETSI 14.8.43: 0 = allowed to request transmission, 1 = not allowed.
     pub transmission_request_permission: bool,
     /// Type2, 6 bits, Notification indicator
     pub notification_indicator: Option<u64>,

--- a/crates/tetra-pdus/src/cmce/pdus/d_tx_continue.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_tx_continue.rs
@@ -16,7 +16,7 @@ pub struct DTxContinue {
     /// Type1, 1 bits, do_Continue
     pub do_continue: bool,
     /// Type1, 1 bits, Transmission request permission
-    /// Set to true to signal MSes they are allowed to send a U-TX DEMAND
+    /// ETSI 14.8.43: 0 = allowed to request transmission, 1 = not allowed.
     pub transmission_request_permission: bool,
     /// Type2, 6 bits, Notification indicator
     pub notification_indicator: Option<u64>,

--- a/crates/tetra-pdus/src/cmce/pdus/d_tx_granted.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_tx_granted.rs
@@ -18,7 +18,7 @@ pub struct DTxGranted {
     /// Type1, 2 bits, Transmission grant
     pub transmission_grant: u8,
     /// Type1, 1 bits, Transmission request permission
-    /// Set to true to signal MSes they are allowed to send a U-TX DEMAND
+    /// ETSI 14.8.43: 0 = allowed to request transmission, 1 = not allowed.
     pub transmission_request_permission: bool,
     /// Type1, 1 bits, Encryption control
     pub encryption_control: bool,


### PR DESCRIPTION
- Reduce initial D-SETUP burst from 4 frames to 1+1 backup
- Fix transmission_request_permission polarity (0 = allowed)
- Send individual D-TX GRANTED then group D-TX GRANTED to GSSI
- Update cached D-SETUP transmission_grant for current call state
- Use BL-UDATA for GSSI-addressed and STCH messages in LLC
- Send BL-ACK via FACCH on traffic timeslots
- Implement STCH second-half-stolen signaling (UMAC → LMAC)
- Drain stale signaling from DL queue when leaving hangtime