### PR TITLE
Throttle late-entry D-SETUP retransmissions based on MCCH load

### DIFF
--- a/crates/tetra-config/src/stack_config.rs
+++ b/crates/tetra-config/src/stack_config.rs
@@ -268,6 +268,9 @@ pub struct StackState {
     pub timeslot_alloc: TimeslotAllocator,
     /// Backhaul/network connection to SwMI (e.g., Brew/TetraPack). False -> fallback mode.
     pub network_connected: bool,
+    /// Number of queued signalling items on MCCH (TS1). Written by UMAC each tick.
+    /// Used by CMCE to suppress optional late-entry D-SETUP when the channel is busy.
+    pub mcch_queue_depth: usize,
 }
 
 impl Default for StackState {
@@ -276,6 +279,7 @@ impl Default for StackState {
             cell_load_ca: 0,
             timeslot_alloc: TimeslotAllocator::default(),
             network_connected: false,
+            mcch_queue_depth: 0,
         }
     }
 }

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -207,6 +207,11 @@ impl BsChannelScheduler {
         }
     }
 
+    /// Returns the number of queued downlink signalling items for a timeslot (1-based).
+    pub fn dl_queue_depth(&self, ts: u8) -> usize {
+        self.dltx_queues[ts as usize - 1].len()
+    }
+
     /// Fully wipe the schedule
     pub fn purge_schedule(&mut self) {
         self.dltx_queues = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1452,6 +1452,9 @@ impl TetraEntityTrait for UmacBs {
             self.channel_scheduler.tick_start(ts);
         }
 
+        // Publish MCCH queue depth so CMCE can throttle optional late-entry D-SETUPs
+        self.config.state_write().mcch_queue_depth = self.channel_scheduler.dl_queue_depth(1);
+
         // Collect/construct traffic that should be sent down to the LMAC
         // This is basically the _previous_ timeslot
         let elem = self.channel_scheduler.finalize_ts_for_tick();


### PR DESCRIPTION
- Fix late-entry interval from 20s to 5s (5*18*4 = 360 timeslots)
- Suppress late-entry D-SETUP when MCCH (TS1) has queued signalling
- Expose MCCH queue depth via StackState for cross-entity visibility
- Add dl_queue_depth() to BsChannelScheduler, write it each tick
- Fix return -> continue bug in cc_bs tick_start SendDSetup handling