### PR TITLE
Route Brew affiliations through Brew ISSI; MM layer improvements

### DIFF
--- a/crates/tetra-entities/src/brew/worker.rs
+++ b/crates/tetra-entities/src/brew/worker.rs
@@ -468,14 +468,14 @@ impl BrewWorker {
         self.message_loop(&mut ws)
     }
 
-    /// Send initial registration and group affiliation
+    /// Send initial registration using the Brew ISSI (routable identity)
     fn send_registration(&mut self, ws: &mut WebSocket<MaybeTlsStream<TcpStream>>) -> Result<(), String> {
-        // Register ISSI
-        let reg_msg = build_subscriber_register(self.brew_config.issi, &[]);
+        let brew_issi = self.brew_config.issi;
+        let reg_msg = build_subscriber_register(brew_issi, &[]);
         ws.send(Message::Binary(reg_msg.into()))
             .map_err(|e| format!("failed to send registration: {}", e))?;
-        tracing::info!("BrewWorker: registered ISSI {}", self.brew_config.issi);
-        self.subscriber_groups.entry(self.brew_config.issi).or_insert_with(HashSet::new);
+        tracing::info!("BrewWorker: registered Brew ISSI {}", brew_issi);
+        self.subscriber_groups.entry(brew_issi).or_insert_with(HashSet::new);
 
         Ok(())
     }

--- a/crates/tetra-entities/src/mm/components/client_state.rs
+++ b/crates/tetra-entities/src/mm/components/client_state.rs
@@ -128,11 +128,10 @@ impl MmClientMgr {
 
         if let Some(client) = self.clients.get_mut(&issi) {
             if do_attach {
-                client.groups.insert(gssi);
+                Ok(client.groups.insert(gssi))
             } else {
-                client.groups.remove(&gssi);
+                Ok(client.groups.remove(&gssi))
             }
-            Ok(true)
         } else {
             Err(ClientMgrErr::ClientNotFound { issi })
         }

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -17,6 +17,7 @@ use tetra_pdus::mm::fields::group_identity_location_accept::GroupIdentityLocatio
 use tetra_pdus::mm::fields::group_identity_uplink::GroupIdentityUplink;
 use tetra_pdus::mm::pdus::d_attach_detach_group_identity_acknowledgement::DAttachDetachGroupIdentityAcknowledgement;
 use tetra_pdus::mm::pdus::d_location_update_accept::DLocationUpdateAccept;
+use tetra_pdus::mm::pdus::d_location_update_command::DLocationUpdateCommand;
 use tetra_pdus::mm::pdus::u_attach_detach_group_identity::UAttachDetachGroupIdentity;
 use tetra_pdus::mm::pdus::u_itsi_detach::UItsiDetach;
 use tetra_pdus::mm::pdus::u_location_update_demand::ULocationUpdateDemand;
@@ -158,6 +159,7 @@ impl MmBs {
 
         // Try to register the client
         let issi = prim.received_address.ssi;
+        let handle = prim.handle;
         let is_new = !self.client_mgr.client_is_known(issi);
         if is_new {
             match self.client_mgr.try_register_client(issi, true) {
@@ -243,6 +245,13 @@ impl MmBs {
             }),
         };
         queue.push_back(msg);
+
+        // If this is an unknown returning radio (not ITSI attach), force it to
+        // re-register with full group report via D-LOCATION UPDATE COMMAND
+        if is_new && pdu.location_update_type != LocationUpdateType::ItsiAttach {
+            tracing::info!("Sending D-LOCATION UPDATE COMMAND to returning MS {} to request group report", issi);
+            Self::send_d_location_update_command(queue, message.dltime, issi, handle);
+        }
     }
 
     fn rx_u_mm_status(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
@@ -309,6 +318,7 @@ impl MmBs {
         };
 
         let issi = prim.received_address.ssi;
+
         let pdu = match UAttachDetachGroupIdentity::from_bitbuf(&mut prim.sdu) {
             Ok(pdu) => {
                 tracing::debug!("<- {:?}", pdu);
@@ -328,20 +338,35 @@ impl MmBs {
 
         // If group_identity_attach_detach_mode == 1, we first detach all groups
         if pdu.group_identity_attach_detach_mode == true {
-            let prior_groups: Vec<u32> = self
-                .client_mgr
-                .get_client_by_issi(issi)
-                .map(|client| client.groups.iter().copied().collect())
-                .unwrap_or_default();
-            match self.client_mgr.client_detach_all_groups(issi) {
-                Ok(_) => {
-                    if !prior_groups.is_empty() {
-                        self.emit_subscriber_update(queue, message.dltime, issi, prior_groups, BrewSubscriberAction::Deaffiliate);
+            if !self.client_mgr.client_is_known(issi) {
+                // Client unknown (e.g. never registered via location update).
+                // Re-register so group attachment can proceed.
+                match self.client_mgr.try_register_client(issi, true) {
+                    Ok(_) => {
+                        self.emit_subscriber_update(queue, message.dltime, issi, Vec::new(), BrewSubscriberAction::Register);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed re-registering MS {} on group attach: {:?}", issi, e);
+                        return;
                     }
                 }
-                Err(e) => {
-                    tracing::warn!("Failed detaching all groups for MS {}: {:?}", issi, e);
-                    return;
+            } else {
+                // Client is known — detach all existing groups first
+                let prior_groups: Vec<u32> = self
+                    .client_mgr
+                    .get_client_by_issi(issi)
+                    .map(|client| client.groups.iter().copied().collect())
+                    .unwrap_or_default();
+                match self.client_mgr.client_detach_all_groups(issi) {
+                    Ok(_) => {
+                        if !prior_groups.is_empty() {
+                            self.emit_subscriber_update(queue, message.dltime, issi, prior_groups, BrewSubscriberAction::Deaffiliate);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed detaching all groups for MS {}: {:?}", issi, e);
+                        return;
+                    }
                 }
             }
         }
@@ -470,7 +495,7 @@ impl MmBs {
                         // We have added the client to this group. Add an entry to the downlink response
                         let gid = GroupIdentityDownlink {
                             group_identity_attachment: Some(GroupIdentityAttachment {
-                                group_identity_attachment_lifetime: 3, // re-attach after location update
+                                group_identity_attachment_lifetime: 1, // re-attach after ITSI attach (ETSI default per clause 16.4.2)
                                 class_of_usage: giu.class_of_usage.unwrap_or(0),
                             }),
                             group_identity_detachment_uplink: None,
@@ -497,6 +522,48 @@ impl MmBs {
         accepted_groups
     }
 
+    /// Sends a D-LOCATION UPDATE COMMAND to force the radio to re-register
+    /// with full group identity report
+    fn send_d_location_update_command(queue: &mut MessageQueue, dltime: TdmaTime, issi: u32, handle: u32) {
+        let pdu = DLocationUpdateCommand {
+            group_identity_report: true,
+            cipher_control: false,
+            ciphering_parameters: None,
+            address_extension: None,
+            cell_type_control: None,
+            proprietary: None,
+        };
+
+        let mut sdu = BitBuffer::new_autoexpand(16);
+        pdu.to_bitbuf(&mut sdu).unwrap();
+        sdu.seek(0);
+        tracing::debug!("-> DLocationUpdateCommand sdu {}", sdu.dump_bin());
+
+        let addr = TetraAddress {
+            encrypted: false,
+            ssi_type: SsiType::Ssi,
+            ssi: issi,
+        };
+        let msg = SapMsg {
+            sap: Sap::LmmSap,
+            src: TetraEntity::Mm,
+            dest: TetraEntity::Mle,
+            dltime,
+            msg: SapMsgInner::LmmMleUnitdataReq(LmmMleUnitdataReq {
+                sdu,
+                handle,
+                address: addr,
+                layer2service: 0,
+                stealing_permission: false,
+                stealing_repeats_flag: false,
+                encryption_flag: false,
+                is_null_pdu: false,
+                tx_reporter: None,
+            }),
+        };
+        queue.push_back(msg);
+    }
+
     fn feature_check_u_itsi_detach(pdu: &UItsiDetach) -> bool {
         let supported = true;
         if pdu.address_extension.is_some() {
@@ -510,8 +577,8 @@ impl MmBs {
 
     fn feature_check_u_location_update_demand(pdu: &ULocationUpdateDemand) -> bool {
         let mut supported = true;
-        if pdu.location_update_type != LocationUpdateType::RoamingLocationUpdating
-            && pdu.location_update_type != LocationUpdateType::ItsiAttach
+        if pdu.location_update_type == LocationUpdateType::MigratingLocationUpdating
+            || pdu.location_update_type == LocationUpdateType::DisabledMsUpdating
         {
             unimplemented_log!("Unsupported {}", pdu.location_update_type);
             supported = false;

--- a/crates/tetra-pdus/src/mm/enums/location_update_type.rs
+++ b/crates/tetra-pdus/src/mm/enums/location_update_type.rs
@@ -5,7 +5,7 @@
 #[repr(u8)]
 pub enum LocationUpdateType {
     RoamingLocationUpdating = 0,
-    TemporaryRegistration = 1,
+    MigratingLocationUpdating = 1,
     PeriodicLocationUpdating = 2,
     ItsiAttach = 3,
     ServiceRestorationRoamingLocationUpdating = 4,
@@ -19,7 +19,7 @@ impl std::convert::TryFrom<u64> for LocationUpdateType {
     fn try_from(x: u64) -> Result<Self, Self::Error> {
         match x {
             0 => Ok(LocationUpdateType::RoamingLocationUpdating),
-            1 => Ok(LocationUpdateType::TemporaryRegistration),
+            1 => Ok(LocationUpdateType::MigratingLocationUpdating),
             2 => Ok(LocationUpdateType::PeriodicLocationUpdating),
             3 => Ok(LocationUpdateType::ItsiAttach),
             4 => Ok(LocationUpdateType::ServiceRestorationRoamingLocationUpdating),
@@ -36,7 +36,7 @@ impl LocationUpdateType {
     pub fn into_raw(self) -> u64 {
         match self {
             LocationUpdateType::RoamingLocationUpdating => 0,
-            LocationUpdateType::TemporaryRegistration => 1,
+            LocationUpdateType::MigratingLocationUpdating => 1,
             LocationUpdateType::PeriodicLocationUpdating => 2,
             LocationUpdateType::ItsiAttach => 3,
             LocationUpdateType::ServiceRestorationRoamingLocationUpdating => 4,
@@ -57,7 +57,7 @@ impl core::fmt::Display for LocationUpdateType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             LocationUpdateType::RoamingLocationUpdating => write!(f, "RoamingLocationUpdating"),
-            LocationUpdateType::TemporaryRegistration => write!(f, "TemporaryRegistration"),
+            LocationUpdateType::MigratingLocationUpdating => write!(f, "MigratingLocationUpdating"),
             LocationUpdateType::PeriodicLocationUpdating => write!(f, "PeriodicLocationUpdating"),
             LocationUpdateType::ItsiAttach => write!(f, "ItsiAttach"),
             LocationUpdateType::ServiceRestorationRoamingLocationUpdating => write!(f, "ServiceRestorationRoamingLocationUpdating"),


### PR DESCRIPTION
Brew:
- Route REGISTER/AFFILIATE/DEAFFILIATE through Brew ISSI, not per-radio ISSIs
- Add group_refcount for per-GSSI reference counting across radios

MM:
- Send D-LOCATION UPDATE COMMAND to returning radios for group re-report
- Re-register unknown clients on U-ATTACH/DETACH GROUP IDENTITY
- Change attachment_lifetime to 1 (ETSI default, clause 16.4.2)
- Accept PeriodicLocationUpdating and DemandLocationUpdating
- Rename TemporaryRegistration to MigratingLocationUpdating (ETSI 16.10.35)
- Fix client_group_attach return value