### PR TITLE
Merge branch 'sds' of https://github.com/russel053/tetra-bluestation

### DIFF
--- a/crates/tetra-entities/src/cmce/cmce_bs.rs
+++ b/crates/tetra-entities/src/cmce/cmce_bs.rs
@@ -58,8 +58,7 @@ impl CmceBs {
                 self.cc.route_xx_deliver(_queue, message);
             }
             CmcePduTypeUl::USdsData => {
-                unimplemented_log!("{:?}", pdu_type);
-                // self.sds.route_xx_deliver(_queue, message);
+                self.sds.route_xx_deliver(_queue, message);
             }
             CmcePduTypeUl::UFacility => {
                 unimplemented_log!("{:?}", pdu_type);

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -1,43 +1,167 @@
 use crate::MessageQueue;
-use tetra_core::unimplemented_log;
+use tetra_core::{BitBuffer, Sap, TetraAddress, address::SsiType, unimplemented_log};
+use tetra_pdus::cmce::{enums::cmce_pdu_type_ul::CmcePduTypeUl, pdus::u_sds_data::USdsData, pdus::d_sds_data::DSdsData};
 use tetra_saps::{SapMsg, SapMsgInner};
+use tetra_saps::lcmc::LcmcMleUnitdataReq;
+use tetra_saps::control::sds::BrewSdsRxInd;
+use tetra_core::tetra_entities::TetraEntity;
 
-use tetra_pdus::cmce::{enums::cmce_pdu_type_dl::CmcePduTypeDl, pdus::d_sds_data::DSdsData};
-
-/// Clause 13 Short Data Service CMCE sub-entity
-pub struct SdsBsSubentity {}
+/// Clause 13 Short Data Service CMCE sub-entity (BS side)
+///
+/// BS primarily receives **U-SDS-DATA** on the air interface and forwards the
+/// SDS Type-4 payload (including PID octet) to Brew/Core.
+///
+/// NOTE: We DO NOT rewrite SDS-TL Message Reference (MR). MR is used end-to-end
+/// (e.g. delivery reports) and must be preserved per ETSI.
+pub struct SdsBsSubentity;
 
 impl SdsBsSubentity {
-    /// Create a new instance of the SdsSubentity
     pub fn new() -> Self {
-        SdsBsSubentity {}
+        SdsBsSubentity
     }
-
-    pub fn rx_sds_data(&mut self, _queue: &mut MessageQueue, mut message: SapMsg) {
-        tracing::trace!("rx_sds_data");
+    fn rx_u_sds_data(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
+        tracing::trace!("rx_u_sds_data");
 
         let SapMsgInner::LcmcMleUnitdataInd(prim) = &mut message.msg else {
             panic!();
         };
-        let _pdu = match DSdsData::from_bitbuf(&mut prim.sdu) {
-            Ok(pdu) => {
-                tracing::debug!("Received DSdsData: {:?}", pdu);
-                pdu
-            }
+
+        let pdu = match USdsData::from_bitbuf(&mut prim.sdu) {
+            Ok(pdu) => pdu,
             Err(e) => {
-                tracing::warn!("Failed parsing DSdsData: {:?} {}", e, prim.sdu.dump_bin());
+                tracing::warn!("Failed parsing USdsData: {:?} {}", e, prim.sdu.dump_bin());
                 return;
             }
         };
 
-        unimplemented_log!("rx_sds_data");
+        // We currently forward only Type-4 (SDTI=3) since it carries a variable-length payload.
+        if pdu.short_data_type_identifier != 3 {
+            tracing::debug!("USdsData sdti={} (not type-4); ignoring", pdu.short_data_type_identifier);
+            return;
+        }
+
+        let Some(bit_len) = pdu.length_indicator else {
+            tracing::warn!("USdsData type-4 missing length_indicator");
+            return;
+        };
+        let Some(payload) = pdu.user_defined_data_4 else {
+            tracing::warn!("USdsData type-4 missing user_defined_data_4");
+            return;
+        };
+
+        // Destination SSI
+        let (dst_ssi, dst_type) = if let Some(ssi) = pdu.called_party_ssi {
+            (ssi as u32, SsiType::Ssi)
+        } else if let Some(short) = pdu.called_party_short_number_address {
+            (short as u32, SsiType::Unknown)
+        } else {
+            tracing::warn!("USdsData missing called_party address");
+            return;
+        };
+
+
+
+        tracing::info!(
+            "SDS RX head: from={} dst={} head={:02x?}",
+            prim.received_tetra_address,
+            tetra_core::TetraAddress::new(dst_ssi, dst_type),
+            payload.get(0..payload.len().min(8)).unwrap_or(&[])
+        );
+        // Interop: do not synthesize SDS-TL REPORTs here.
+        // Many terminals accept only the destination-generated SDS-REPORT.
+        // We relay destination reports end-to-end in BrewEntity.
+        let ind = BrewSdsRxInd {
+            source: prim.received_tetra_address,
+            destination: tetra_core::TetraAddress::new(dst_ssi, dst_type),
+            payload,
+            bit_length: bit_len,
+        };
+
+        tracing::info!(
+            "SDS RX: from={} dst={} bits={} bytes={}",
+            ind.source,
+            ind.destination,
+            ind.bit_length,
+            ind.payload.len()
+        );
+
+        // Forward to Brew entity via Control SAP.
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Brew,
+            dltime: message.dltime,
+            msg: SapMsgInner::BrewSdsRxInd(ind),
+        });
     }
 
-    /// Poor man's rx_prim, as this is a subcomponent and not governed by the MessageRouter
-    /// If need be, we can deviate from the standard's subentity ranking and make this a full-fledged component
-    /// See Figure 14.2: Block view of CMCE-MS
-    pub fn route_rf_deliver(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
-        tracing::trace!("route_rf_deliver");
+    #[allow(dead_code)]
+    fn send_sds_tl_report_to_source(
+        &mut self,
+        queue: &mut MessageQueue,
+        dltime: tetra_core::TdmaTime,
+        handle: u32,
+        endpoint_id: u32,
+        link_id: u32,
+        source_addr: TetraAddress,
+        report_sender_ssi: u32,
+        raw4: [u8; 4],
+    ) {
+        // Build a minimal D-SDS-DATA Type-4 with 32-bit SDS-TL status payload (PID + type + status + MR)
+        let pdu = DSdsData {
+            calling_party_type_identifier: 1,
+            calling_party_address_ssi: Some(report_sender_ssi as u64),
+            calling_party_extension: None,
+            short_data_type_identifier: 3,
+            user_defined_data_1: None,
+            user_defined_data_2: None,
+            user_defined_data_3: None,
+            length_indicator: Some(32),
+            user_defined_data_4: Some(raw4.to_vec()),
+            external_subscriber_number: None,
+            dm_ms_address: None,
+        };
+
+        let mut sdu = BitBuffer::new_autoexpand(96);
+        if let Err(e) = pdu.to_bitbuf(&mut sdu) {
+            tracing::warn!("SDS TX REPORT: encode failed: {:?}", e);
+            return;
+        }
+        sdu.seek(0);
+
+        tracing::info!(
+            "SDS TX REPORT: to={} from_ssi={} raw4={:02x?}",
+            source_addr,
+            report_sender_ssi,
+            raw4
+        );
+
+        queue.push_back(SapMsg {
+            sap: Sap::LcmcSap,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Mle,
+            dltime,
+            msg: SapMsgInner::LcmcMleUnitdataReq(LcmcMleUnitdataReq {
+                sdu,
+                handle,
+                endpoint_id,
+                link_id,
+                layer2service: 0,
+                pdu_prio: 0,
+                layer2_qos: 0,
+                stealing_permission: false,
+                stealing_repeats_flag: false,
+                chan_alloc: None,
+                main_address: source_addr,
+                tx_reporter: None,
+            }),
+        });
+    }
+
+
+    /// Poor man's rx_prim, as this is a subcomponent and not governed by the MessageRouter.
+    pub fn route_xx_deliver(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
+        tracing::trace!("route_xx_deliver");
 
         let SapMsgInner::LcmcMleUnitdataInd(prim) = &mut message.msg else {
             panic!();
@@ -47,22 +171,14 @@ impl SdsBsSubentity {
             return;
         };
 
-        let Ok(pdu_type) = CmcePduTypeDl::try_from(bits) else {
+        let Ok(pdu_type) = CmcePduTypeUl::try_from(bits) else {
             tracing::warn!("invalid pdu type: {} in {}", bits, prim.sdu.dump_bin());
             return;
         };
 
-        // TODO FIXME: Besides these PDUs, we can also receive several signals (BUSY ind, CLOSE ind, etc)
         match pdu_type {
-            CmcePduTypeDl::DSdsData => {
-                self.rx_sds_data(queue, message);
-            }
-            CmcePduTypeDl::DStatus => {
-                unimplemented_log!("rx_prim not implemented for SDS DStatus PDU");
-            }
-            _ => {
-                panic!();
-            }
+            CmcePduTypeUl::USdsData => self.rx_u_sds_data(queue, message),
+            _ => unimplemented_log!("SdsBsSubentity route_xx_deliver {:?}", pdu_type),
         }
     }
 }

--- a/crates/tetra-pdus/src/cmce/enums/sds_protocol_id.rs
+++ b/crates/tetra-pdus/src/cmce/enums/sds_protocol_id.rs
@@ -27,6 +27,8 @@ pub enum SdsProtocolId {
     MessageWithUserDataHeader = 138,
     ConcatenatedSdsMessageSdsTl = 140,
     AgnssServiceSdsTl = 141,
+    /// TCCA Callout Service (commonly carried in SDS Type-4)
+    Callout = 195,
 }
 
 impl std::convert::TryFrom<u64> for SdsProtocolId {
@@ -57,6 +59,7 @@ impl std::convert::TryFrom<u64> for SdsProtocolId {
             138 => Ok(SdsProtocolId::MessageWithUserDataHeader),
             140 => Ok(SdsProtocolId::ConcatenatedSdsMessageSdsTl),
             141 => Ok(SdsProtocolId::AgnssServiceSdsTl),
+            195 => Ok(SdsProtocolId::Callout),
             _ => Err(()),
         }
     }
@@ -90,6 +93,7 @@ impl SdsProtocolId {
             SdsProtocolId::MessageWithUserDataHeader => 138,
             SdsProtocolId::ConcatenatedSdsMessageSdsTl => 140,
             SdsProtocolId::AgnssServiceSdsTl => 141,
+            SdsProtocolId::Callout => 195,
         }
     }
 }
@@ -127,6 +131,7 @@ impl core::fmt::Display for SdsProtocolId {
             SdsProtocolId::MessageWithUserDataHeader => write!(f, "MessageWithUserDataHeader"),
             SdsProtocolId::ConcatenatedSdsMessageSdsTl => write!(f, "ConcatenatedSdsMessageSdsTl"),
             SdsProtocolId::AgnssServiceSdsTl => write!(f, "AgnssServiceSdsTl"),
+            SdsProtocolId::Callout => write!(f, "Callout"),
         }
     }
 }

--- a/crates/tetra-pdus/src/cmce/pdus/u_sds_data.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/u_sds_data.rs
@@ -1,3 +1,27 @@
+
+
+fn read_bits_to_padded_bytes(buffer: &mut BitBuffer, num_bits: usize) -> Result<Vec<u8>, PduParseErr> {
+    let num_bytes = (num_bits + 7) / 8;
+    let mut out = BitBuffer::new(num_bytes * 8);
+    let mut remaining = num_bits;
+    while remaining > 0 {
+        let chunk = usize::min(remaining, 64);
+        let v = buffer.read_field(chunk, "type4_payload")?;
+        out.write_bits(v, chunk);
+        remaining -= chunk;
+    }
+    Ok(out.into_bytes())
+}
+
+fn write_padded_bytes_bits(buffer: &mut BitBuffer, data: &[u8], num_bits: usize) -> Result<(), PduParseErr> {
+    let mut src = BitBuffer::from_bytes(data);
+    src.seek(0);
+    if src.get_len() < num_bits {
+        return Err(PduParseErr::BufferEnded { field: Some("type4_payload") });
+    }
+    buffer.copy_bits(&mut src, num_bits);
+    Ok(())
+}
 use core::fmt;
 
 use crate::cmce::enums::{cmce_pdu_type_ul::CmcePduTypeUl, type3_elem_id::CmceType3ElemId};
@@ -35,9 +59,9 @@ pub struct USdsData {
     /// Conditional 64 bits, See note 2, condition: short_data_type_identifier == 2
     pub user_defined_data_3: Option<u64>,
     /// Conditional 11 bits, See note 2, condition: short_data_type_identifier == 3
-    pub length_indicator: Option<u64>,
+    pub length_indicator: Option<u16>,
     /// Conditional See note 2, condition: short_data_type_identifier == 3
-    pub user_defined_data_4: Option<u64>,
+    pub user_defined_data_4: Option<Vec<u8>>,
     /// Type3, External subscriber number
     pub external_subscriber_number: Option<Type3FieldGeneric>,
     /// Type3, DM-MS address
@@ -95,14 +119,14 @@ impl USdsData {
         };
         // Conditional
         let length_indicator = if short_data_type_identifier == 3 {
-            Some(buffer.read_field(11, "length_indicator")?)
+            Some(buffer.read_field(11, "length_indicator")? as u16)
         } else {
             None
         };
         // Conditional
         let user_defined_data_4 = if short_data_type_identifier == 3 {
-            unimplemented!();
-            Some(buffer.read_field(999, "user_defined_data_4")?)
+            let li = length_indicator.unwrap_or(0) as usize;
+            Some(read_bits_to_padded_bytes(buffer, li)?)
         } else {
             None
         };
@@ -174,13 +198,14 @@ impl USdsData {
             buffer.write_bits(*value, 64);
         }
         // Conditional
-        if let Some(ref value) = self.length_indicator {
-            buffer.write_bits(*value, 11);
+        if let Some(value) = self.length_indicator {
+            buffer.write_bits(value as u64, 11);
         }
         // Conditional
-        if let Some(ref _value) = self.user_defined_data_4 {
-            unimplemented!();
-            buffer.write_bits(*_value, 999);
+        // `&self.user_defined_data_4` is a reference; matching implicitly borrows.
+        // Do not use an explicit `ref` binding modifier.
+        if let (Some(bit_len), Some(bytes)) = (self.length_indicator, &self.user_defined_data_4) {
+            write_padded_bytes_bits(buffer, bytes, bit_len as usize)?;
         }
 
         // Check if any optional field present and place o-bit

--- a/crates/tetra-saps/src/control/mod.rs
+++ b/crates/tetra-saps/src/control/mod.rs
@@ -1,3 +1,4 @@
 pub mod brew;
 pub mod call_control;
+pub mod sds;
 pub mod enums;

--- a/crates/tetra-saps/src/control/sds.rs
+++ b/crates/tetra-saps/src/control/sds.rs
@@ -1,0 +1,16 @@
+use tetra_core::TetraAddress;
+
+/// Uplink SDS indication from CMCE to Brew.
+///
+/// Payload is the SDS Type-4 user data bits, represented as padded bytes.
+/// The first octet is typically the SDS Protocol Identifier (PID) as per ETSI.
+#[derive(Debug, Clone)]
+pub struct BrewSdsRxInd {
+    pub source: TetraAddress,
+    /// Called party SSI (may be ISSI or GSSI; the stack may not always know which).
+    pub destination: TetraAddress,
+    /// SDS payload bytes (padded in the last byte if bit_length is not a multiple of 8).
+    pub payload: Vec<u8>,
+    /// Payload length in bits.
+    pub bit_length: u16,
+}

--- a/crates/tetra-saps/src/sapmsg.rs
+++ b/crates/tetra-saps/src/sapmsg.rs
@@ -6,6 +6,7 @@ use tetra_core::tetra_entities::TetraEntity;
 
 use crate::control::brew::MmSubscriberUpdate;
 use crate::control::call_control::CallControl;
+use crate::control::sds::BrewSdsRxInd;
 use crate::tmd::TmdCircuitDataInd;
 use crate::tmd::TmdCircuitDataReq;
 use crate::tnmm::TnmmTestDemand;
@@ -80,6 +81,10 @@ pub enum SapMsgInner {
     // MM -> Brew/CMCE subscriber update
     MmSubscriberUpdate(MmSubscriberUpdate),
 
+    // CMCE -> Brew SDS indication (uplink)
+    BrewSdsRxInd(BrewSdsRxInd),
+
+
     // LTPD-SAP (MLE-LTPD)
     LtpdMleUnitdataInd(LtpdMleUnitdataInd),
 
@@ -114,7 +119,7 @@ impl Display for SapMsgInner {
             // TLB-SAP
             // SapMsgInner::TlbTlSyncInd(_) => write!(f, "TlbTlSyncInd"),
             // SapMsgInner::TlbTlSysinfoInd(_) => write!(f, "TlbTlSysinfoInd"),
-            _ => panic!("Unknown SapMsgInner type"),
+            _ => write!(f, "{:?}", self),
         }
     }
 }


### PR DESCRIPTION
Title: Merge SDS Type-4 + Brew SDS bridging (ShortTransfer/SDS frames) and improve delivery reporting

Body:

Implement full SDS Type-4 parsing/encoding for U-SDS-DATA and D-SDS-DATA (length indicator + variable user defined data-4).

Add CMCE BS SDS subentity to route uplink U-SDS-DATA (Type-4) into Brew via Control SAP (BrewSdsRxInd).

Extend Brew protocol to support CALL_STATE_SHORT_TRANSFER, FRAME_TYPE_SDS_TRANSFER, and FRAME_TYPE_SDS_REPORT (parse + build).

Fix BrewWorker event/command enums and wire SDS events/commands end-to-end.

In BrewEntity:

Stage SHORT_TRANSFER and SDS_TRANSFER (out-of-order tolerant).

Inject downlink SDS on MCCH/TS1 with stealing disabled to avoid voice interference.

Add local MS↔MS SDS relay, PID=0x04 report/ack routing back to origin, and minimal SDS-TL ACK assist to improve sender-side delivery indication. # Conflicts:
#	crates/tetra-entities/src/brew/entity.rs
#	crates/tetra-entities/src/cmce/components/circuit_mgr.rs #	crates/tetra-entities/src/cmce/subentities/cc_bs.rs #	crates/tetra-entities/src/llc/llc_bs_ms.rs
#	crates/tetra-entities/src/lmac/lmac_bs.rs
#	crates/tetra-entities/src/mle/mle_bs_ms.rs
#	crates/tetra-entities/src/phy/components/soapyio.rs #	crates/tetra-entities/src/umac/subcomp/bs_sched.rs #	crates/tetra-entities/src/umac/umac_bs.rs