### PR TITLE
Add UL inactivity timeout to detect stuck/disappeared radios mid-TX

### DIFF
--- a/crates/tetra-entities/src/brew/entity.rs
+++ b/crates/tetra-entities/src/brew/entity.rs
@@ -833,6 +833,8 @@ impl TetraEntityTrait for BrewEntity {
             }) => {
                 self.rx_network_call_ready(brew_uuid, call_id, ts, usage);
             }
+            // UlInactivityTimeout is UMAC→CMCE only; Brew handles FloorReleased instead
+            SapMsgInner::CmceCallControl(CallControl::UlInactivityTimeout { .. }) => {}
             SapMsgInner::MmSubscriberUpdate(update) => {
                 self.handle_subscriber_update(update);
             }

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -155,6 +155,10 @@ impl BsChannelScheduler {
         );
     }
 
+    pub fn is_hangtime(&self, ts: u8) -> bool {
+        self.hangtime[ts as usize - 1]
+    }
+
     fn is_hangtime_effective(&self, ts: u8) -> bool {
         let idx = ts as usize - 1;
         if !self.hangtime[idx] {

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -57,6 +57,9 @@ pub struct UmacBs {
     /// Access to this field is used only by testing code
     pub channel_scheduler: BsChannelScheduler,
     // ulrx_scheduler: UlScheduler,
+    /// Timestamp of last received UL voice frame per timeslot (0-indexed: ts1..ts4).
+    /// Used to detect UL inactivity when a radio disappears mid-transmission.
+    last_ul_voice: [Option<TdmaTime>; 4],
 }
 
 struct PendingStch {
@@ -83,6 +86,7 @@ impl UmacBs {
             pending_stch: None,
             // event_label_store: EventLabelStore::new(),
             channel_scheduler: BsChannelScheduler::new(scrambling_code, precomps),
+            last_ul_voice: [None; 4],
         }
     }
 
@@ -1232,6 +1236,11 @@ impl UmacBs {
             // DL voice from Brew/upper layer → schedule for DL transmission
             SapMsgInner::TmdCircuitDataReq(prim) => {
                 let ts = prim.ts;
+                // Refresh UL inactivity timer when DL voice is being fed (network call scenario).
+                // This prevents false timeout when Brew is the speaker and no UL radio is transmitting.
+                if (1..=4).contains(&ts) && self.channel_scheduler.circuit_is_active(Direction::Ul, ts) {
+                    self.last_ul_voice[ts as usize - 1] = Some(self.dltime);
+                }
                 if self.channel_scheduler.circuit_is_active(Direction::Dl, ts) {
                     self.channel_scheduler.dl_schedule_tmd(ts, prim.data);
                 } else {
@@ -1247,6 +1256,11 @@ impl UmacBs {
             SapMsgInner::TmdCircuitDataInd(prim) => {
                 let ts = prim.ts;
                 let data = prim.data;
+
+                // Track last UL voice frame time for inactivity detection
+                if (1..=4).contains(&ts) {
+                    self.last_ul_voice[ts as usize - 1] = Some(self.dltime);
+                }
 
                 // Forward UL voice to Brew (User plane) if loaded
                 if self.config.config().brew.is_some() {
@@ -1390,6 +1404,12 @@ impl UmacBs {
                 etee_encrypted: circuit.etee_encrypted,
             };
             self.channel_scheduler.create_circuit(d, c);
+
+            // Start UL inactivity timer when opening a UL circuit
+            if d == Direction::Ul && (1..=4).contains(&ts) {
+                self.last_ul_voice[ts as usize - 1] = Some(self.dltime);
+            }
+
             tracing::debug!("  rx_control_circuit_open: Setup {:?} circuit for ts {}", d, ts);
         }
     }
@@ -1410,11 +1430,56 @@ impl UmacBs {
         for d in dirs {
             match self.channel_scheduler.close_circuit(d, ts) {
                 Some(_) => {
+                    // Clear UL inactivity timer when closing a UL circuit
+                    if d == Direction::Ul && (1..=4).contains(&ts) {
+                        self.last_ul_voice[ts as usize - 1] = None;
+                    }
                     tracing::info!("  rx_control_circuit_close: Closed {:?} circuit for ts {}", d, ts);
                 }
                 None => {
                     tracing::warn!("  rx_control_circuit_close: No {:?} circuit to close for ts {}", d, ts);
                 }
+            }
+        }
+    }
+
+    /// Check for UL inactivity on traffic timeslots. If no voice frames have arrived
+    /// for UL_INACTIVITY_TIMESLOTS on a timeslot with an active UL circuit (and not in
+    /// hangtime), send UlInactivityTimeout to CMCE.
+    fn check_ul_inactivity(&mut self, queue: &mut MessageQueue) {
+        // 18 multiframes × 18 frames × 4 timeslots = 1296 timeslots ≈ 18.36s
+        const UL_INACTIVITY_TIMESLOTS: i32 = 18 * 18 * 4;
+
+        for ts in 1..=4u8 {
+            let idx = ts as usize - 1;
+
+            // Only check timeslots with an active UL circuit
+            if !self.channel_scheduler.circuit_is_active(Direction::Ul, ts) {
+                continue;
+            }
+
+            // Skip if in hangtime (no voice expected)
+            if self.channel_scheduler.is_hangtime(ts) {
+                continue;
+            }
+
+            // Check if we've exceeded the inactivity threshold
+            let timed_out = match self.last_ul_voice[idx] {
+                Some(t) => t.age(self.dltime) > UL_INACTIVITY_TIMESLOTS,
+                None => false, // Initialized at circuit open; shouldn't be None here
+            };
+
+            if timed_out {
+                tracing::warn!("UL inactivity timeout on ts={}, sending notification to CMCE", ts);
+                self.last_ul_voice[idx] = None;
+
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Umac,
+                    dest: TetraEntity::Cmce,
+                    dltime: self.dltime,
+                    msg: SapMsgInner::CmceCallControl(CallControl::UlInactivityTimeout { ts }),
+                });
             }
         }
     }
@@ -1435,13 +1500,27 @@ impl UmacBs {
             // Floor-control signals drive traffic↔signalling transitions during hangtime.
             CallControl::FloorReleased { ts, .. } => {
                 self.channel_scheduler.set_hangtime(ts, true);
+                // Stop checking UL inactivity during hangtime
+                if (1..=4).contains(&ts) {
+                    self.last_ul_voice[ts as usize - 1] = None;
+                }
             }
             CallControl::FloorGranted { ts, .. } => {
                 self.channel_scheduler.set_hangtime(ts, false);
+                // Restart UL inactivity timer when new speaker gets floor
+                if (1..=4).contains(&ts) {
+                    self.last_ul_voice[ts as usize - 1] = Some(self.dltime);
+                }
             }
             CallControl::CallEnded { ts, .. } => {
                 self.channel_scheduler.set_hangtime(ts, false);
+                if (1..=4).contains(&ts) {
+                    self.last_ul_voice[ts as usize - 1] = None;
+                }
             }
+
+            // UlInactivityTimeout is UMAC→CMCE only, UMAC won't receive it back
+            CallControl::UlInactivityTimeout { .. } => {}
 
             // NetworkCall* are for CMCE ↔ Brew, not UMAC (for now)
             CallControl::NetworkCallStart { .. } | CallControl::NetworkCallReady { .. } | CallControl::NetworkCallEnd { .. } => {
@@ -1500,6 +1579,9 @@ impl TetraEntityTrait for UmacBs {
             // When running, we adopt the new time and check for desync
             self.channel_scheduler.tick_start(ts);
         }
+
+        // Check for UL inactivity (stuck transmitter detection)
+        self.check_ul_inactivity(queue);
 
         // Collect/construct traffic that should be sent down to the LMAC
         // This is basically the _previous_ timeslot

--- a/crates/tetra-saps/src/control/call_control.rs
+++ b/crates/tetra-saps/src/control/call_control.rs
@@ -73,4 +73,7 @@ pub enum CallControl {
     NetworkCallEnd {
         brew_uuid: uuid::Uuid, // Identifies the call to end
     },
+    /// UL inactivity detected on a traffic timeslot — no voice frames received
+    /// for the timeout period. Sent by UMAC to CMCE.
+    UlInactivityTimeout { ts: u8 },
 }


### PR DESCRIPTION
- Add UlInactivityTimeout variant to CallControl SAP enum
- UMAC: track last UL voice frame time per timeslot (last_ul_voice)
- UMAC: check_ul_inactivity fires after ~18s of silence on active UL circuit
- UMAC: manage timer lifecycle on circuit open/close, floor grant/release, call end
- UMAC: refresh timer on DL voice (TmdCircuitDataReq) to avoid false positives on network-originated Brew calls
- CMCE: handle_ul_inactivity_timeout forces TX ceased + hangtime, mirrors rx_u_tx_ceased logic
- Brew: ignore UlInactivityTimeout (UMAC→CMCE only, Brew uses FloorReleased)
- BsChannelScheduler: expose is_hangtime() for inactivity check