### PR TITLE
Route non-local SDS via Brew presence query

### DIFF
--- a/crates/tetra-entities/src/brew/components/brew_routable.rs
+++ b/crates/tetra-entities/src/brew/components/brew_routable.rs
@@ -62,10 +62,3 @@ pub fn is_brew_issi_routable(config: &SharedConfig, issi: u32) -> bool {
         true
     }
 }
-
-/// Check if an ISSI is a known TetraPack service destination for SDS.
-/// FIXME: move to config-based whitelist instead of hardcoding
-pub fn is_tetrapack_sds_service_issi(config: &SharedConfig, issi: u32) -> bool {
-    const TETRAPACK_SERVICE_ISSI: &[u32] = &[200999, 262993];
-    is_tetrapack(config) && TETRAPACK_SERVICE_ISSI.contains(&issi)
-}

--- a/crates/tetra-entities/src/brew/entity.rs
+++ b/crates/tetra-entities/src/brew/entity.rs
@@ -33,8 +33,6 @@ const BREW_EXPECTED_FRAME_INTERVAL_US: f64 = 56_667.0;
 const BREW_JITTER_WARN_TARGET_FRAMES: usize = 8;
 /// Rate-limit warning logs per call.
 const BREW_JITTER_WARN_INTERVAL: Duration = Duration::from_secs(5);
-/// Maximum time to wait for Brew subscriber presence before dropping queued SDS.
-const SDS_ROUTE_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ─── Active call tracking ─────────────────────────────────────────
 
@@ -1186,7 +1184,7 @@ impl BrewEntity {
 
     fn expire_pending_sds_queries(&mut self) {
         self.pending_sds_queries.retain(|issi, pending| {
-            if pending.requested_at.elapsed() >= SDS_ROUTE_QUERY_TIMEOUT {
+            if pending.requested_at.elapsed() >= HEARTBEAT_TIMEOUT {
                 tracing::warn!("ISSI ({}) is not Routeable Locally or Externally, Dropping", issi);
                 false
             } else {

--- a/crates/tetra-entities/src/brew/entity.rs
+++ b/crates/tetra-entities/src/brew/entity.rs
@@ -33,6 +33,8 @@ const BREW_EXPECTED_FRAME_INTERVAL_US: f64 = 56_667.0;
 const BREW_JITTER_WARN_TARGET_FRAMES: usize = 8;
 /// Rate-limit warning logs per call.
 const BREW_JITTER_WARN_INTERVAL: Duration = Duration::from_secs(5);
+/// Maximum time to wait for Brew subscriber presence before dropping queued SDS.
+const SDS_ROUTE_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ─── Active call tracking ─────────────────────────────────────────
 
@@ -96,6 +98,12 @@ struct JitterFrame {
     rx_seq: u64,
     rx_at: Instant,
     acelp_data: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct PendingSdsQuery {
+    requested_at: Instant,
+    messages: Vec<CmceSdsData>,
 }
 
 #[derive(Debug, Default)]
@@ -254,6 +262,9 @@ pub struct BrewEntity {
     /// Registered subscriber groups (ISSI -> set of GSSIs)
     subscriber_groups: HashMap<u32, HashSet<u32>>,
 
+    /// Pending SDS messages awaiting Brew subscriber profile lookup, keyed by destination ISSI
+    pending_sds_queries: HashMap<u32, PendingSdsQuery>,
+
     /// Whether the worker is connected
     connected: bool,
 
@@ -294,6 +305,7 @@ impl BrewEntity {
             hanging_calls: HashMap::new(),
             ul_forwarded: HashMap::new(),
             subscriber_groups: HashMap::new(),
+            pending_sds_queries: HashMap::new(),
             connected: false,
             worker_handle: Some(handle),
         }
@@ -312,6 +324,13 @@ impl BrewEntity {
                 BrewEvent::Disconnected(reason) => {
                     tracing::debug!("BrewEntity: disconnected: {}", reason); // Already warned in worker
                     self.set_network_connected(false);
+                    if !self.pending_sds_queries.is_empty() {
+                        tracing::warn!(
+                            "BrewEntity: dropping {} pending SDS presence queries after disconnect",
+                            self.pending_sds_queries.len()
+                        );
+                        self.pending_sds_queries.clear();
+                    }
                     // Release all active calls
                     self.release_all_calls(queue);
                 }
@@ -345,6 +364,9 @@ impl BrewEntity {
                 }
                 BrewEvent::SubscriberEvent { msg_type, issi, groups } => {
                     tracing::debug!("BrewEntity: subscriber event type={} issi={} groups={:?}", msg_type, issi, groups);
+                }
+                BrewEvent::SubscriberProfiles { queried_issis, profiles } => {
+                    self.handle_subscriber_profiles(queried_issis, profiles);
                 }
                 BrewEvent::ServerError { error_type, data } => {
                     tracing::error!("BrewEntity: server error type={} data={} bytes", error_type, data.len());
@@ -809,6 +831,7 @@ impl TetraEntityTrait for BrewEntity {
         self.dltime = ts;
         // Process all pending events from the worker thread
         self.process_events(queue);
+        self.expire_pending_sds_queries();
         // Feed one buffered frame at each traffic playout opportunity.
         self.drain_jitter_playout(queue);
         // Expire hanging calls that have exceeded hangtime
@@ -1108,7 +1131,7 @@ impl BrewEntity {
     }
 
     /// Handle outgoing SDS from CMCE → Brew (local MS → network)
-    fn handle_sds_send(&self, sds: CmceSdsData) {
+    fn handle_sds_send(&mut self, sds: CmceSdsData) {
         if !self.connected {
             tracing::warn!(
                 "BrewEntity: not connected, dropping outgoing SDS {} -> {}",
@@ -1118,6 +1141,61 @@ impl BrewEntity {
             return;
         }
 
+        if let Some(pending) = self.pending_sds_queries.get_mut(&sds.dest_issi) {
+            pending.messages.push(sds);
+            return;
+        }
+
+        let dest_issi = sds.dest_issi;
+        if let Err(e) = self.command_sender.send(BrewCommand::QuerySubscribers { issis: vec![dest_issi] }) {
+            tracing::warn!("BrewEntity: failed to request Brew subscriber presence for {}: {}", dest_issi, e);
+            return;
+        }
+
+        tracing::info!("BrewEntity: querying Brew subscriber presence for ISSI {}", dest_issi);
+        self.pending_sds_queries.insert(
+            dest_issi,
+            PendingSdsQuery {
+                requested_at: Instant::now(),
+                messages: vec![sds],
+            },
+        );
+    }
+
+    fn handle_subscriber_profiles(&mut self, queried_issis: Vec<u32>, profiles: HashMap<u32, super::protocol::BrewSubscriberProfile>) {
+        for issi in queried_issis {
+            let Some(pending) = self.pending_sds_queries.remove(&issi) else {
+                tracing::debug!("BrewEntity: subscriber profile response for ISSI {} without pending SDS", issi);
+                continue;
+            };
+
+            if profiles.get(&issi).and_then(|profile| profile.status) == Some(1) {
+                tracing::info!(
+                    "BrewEntity: Brew presence confirmed for ISSI {}, routing {} queued SDS message(s)",
+                    issi,
+                    pending.messages.len()
+                );
+                for sds in pending.messages {
+                    self.send_sds_to_brew(sds);
+                }
+            } else {
+                tracing::warn!("ISSI ({}) is not Routeable Locally or Externally, Dropping", issi);
+            }
+        }
+    }
+
+    fn expire_pending_sds_queries(&mut self) {
+        self.pending_sds_queries.retain(|issi, pending| {
+            if pending.requested_at.elapsed() >= SDS_ROUTE_QUERY_TIMEOUT {
+                tracing::warn!("ISSI ({}) is not Routeable Locally or Externally, Dropping", issi);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    fn send_sds_to_brew(&self, sds: CmceSdsData) {
         let uuid = Uuid::new_v4();
         tracing::info!(
             "BrewEntity: sending SDS uuid={} src={} dst={} type={} {} bits",

--- a/crates/tetra-entities/src/brew/mod.rs
+++ b/crates/tetra-entities/src/brew/mod.rs
@@ -10,4 +10,3 @@ pub use components::brew_routable::feature_sds_enabled;
 pub use components::brew_routable::is_active;
 pub use components::brew_routable::is_brew_gssi_routable;
 pub use components::brew_routable::is_brew_issi_routable;
-pub use components::brew_routable::is_tetrapack_sds_service_issi;

--- a/crates/tetra-entities/src/brew/protocol.rs
+++ b/crates/tetra-entities/src/brew/protocol.rs
@@ -1,5 +1,8 @@
 //! Brew protocol binary message parsing and serialization (2-byte [kind, type] prefix, little-endian)
 
+use std::collections::HashMap;
+
+use serde::Deserialize;
 use uuid::Uuid;
 
 // ─── Message classes ───────────────────────────────────────────────
@@ -122,6 +125,20 @@ pub struct BrewErrorMessage {
 pub struct BrewServiceMessage {
     pub service_type: u8,
     pub json_data: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct BrewSubscriberProfile {
+    #[serde(default)]
+    pub call: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub active: Option<bool>,
+    #[serde(default)]
+    pub status: Option<u8>,
+    #[serde(default)]
+    pub date: Option<String>,
 }
 
 // ─── Parsing ──────────────────────────────────────────────────────
@@ -506,6 +523,21 @@ pub fn build_query_subscribers(issis: &[u32]) -> Vec<u8> {
     buf
 }
 
+pub fn parse_subscriber_profiles(json_data: &str) -> Result<HashMap<u32, BrewSubscriberProfile>, String> {
+    let raw_profiles: HashMap<String, BrewSubscriberProfile> =
+        serde_json::from_str(json_data).map_err(|e| format!("invalid subscriber profile JSON: {}", e))?;
+
+    let mut profiles = HashMap::with_capacity(raw_profiles.len());
+    for (issi, profile) in raw_profiles {
+        let issi = issi
+            .parse::<u32>()
+            .map_err(|e| format!("invalid subscriber profile ISSI '{}': {}", issi, e))?;
+        profiles.insert(issi, profile);
+    }
+
+    Ok(profiles)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -661,5 +693,36 @@ mod tests {
         } else {
             panic!("Expected Frame message");
         }
+    }
+
+    #[test]
+    fn test_build_query_subscribers_appends_null_terminator() {
+        let built = build_query_subscribers(&[1_234_567]);
+        assert_eq!(built[0], BREW_CLASS_SERVICE);
+        assert_eq!(built[1], 1);
+        assert_eq!(built.last().copied(), Some(0));
+    }
+
+    #[test]
+    fn test_parse_subscriber_profiles() {
+        let profiles = parse_subscriber_profiles(
+            r#"{
+                "1234567": {
+                    "call": "N0CALL",
+                    "text": "APRS text",
+                    "active": true,
+                    "status": 1,
+                    "date": "2025-03-10T00:00:00.000000Z"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let profile = profiles.get(&1_234_567).unwrap();
+        assert_eq!(profile.call.as_deref(), Some("N0CALL"));
+        assert_eq!(profile.text.as_deref(), Some("APRS text"));
+        assert_eq!(profile.active, Some(true));
+        assert_eq!(profile.status, Some(1));
+        assert_eq!(profile.date.as_deref(), Some("2025-03-10T00:00:00.000000Z"));
     }
 }

--- a/crates/tetra-entities/src/brew/worker.rs
+++ b/crates/tetra-entities/src/brew/worker.rs
@@ -1,6 +1,6 @@
 //! Brew WebSocket worker thread handling HTTP Digest Auth, TLS, and bidirectional Brew message exchange
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
@@ -60,6 +60,12 @@ pub enum BrewEvent {
     /// SDS report received
     SdsReport { uuid: Uuid, status: u8 },
 
+    /// Subscriber profile response received for an SDS routing query
+    SubscriberProfiles {
+        queried_issis: Vec<u32>,
+        profiles: HashMap<u32, BrewSubscriberProfile>,
+    },
+
     /// Error from server
     ServerError { error_type: u8, data: Vec<u8> },
 }
@@ -105,6 +111,9 @@ pub enum BrewCommand {
 
     /// Send SDS report to Brew (delivery acknowledgement)
     SendSdsReport { uuid: Uuid, status: u8 },
+
+    /// Query Brew for external subscriber presence before routing SDS
+    QuerySubscribers { issis: Vec<u32> },
 
     /// Disconnect gracefully
     Disconnect,
@@ -274,6 +283,8 @@ pub struct BrewWorker {
     subscriber_groups: HashMap<u32, HashSet<u32>>,
     /// Pending SDS transfers keyed by UUID, awaiting matching SDS_TRANSFER frame
     pending_sds: HashMap<Uuid, PendingSds>,
+    /// Outstanding subscriber presence queries awaiting a type-2 service response
+    pending_subscriber_queries: VecDeque<Vec<u32>>,
 }
 
 impl BrewWorker {
@@ -286,6 +297,7 @@ impl BrewWorker {
             command_receiver,
             subscriber_groups: HashMap::new(),
             pending_sds: HashMap::new(),
+            pending_subscriber_queries: VecDeque::new(),
         }
     }
 
@@ -742,6 +754,20 @@ impl BrewWorker {
                             tracing::debug!("BrewWorker: sent SDS_REPORT uuid={} status={}", uuid, status);
                         }
                     }
+                    BrewCommand::QuerySubscribers { issis } => {
+                        if !brew::feature_sds_enabled(&self.config) {
+                            tracing::warn!("BrewWorker: ignoring QuerySubscribers command because SDS over Brew is disabled in config");
+                            continue;
+                        }
+
+                        let msg = build_query_subscribers(&issis);
+                        if let Err(e) = ws.send(Message::Binary(msg.into())) {
+                            tracing::error!("BrewWorker: failed to send subscriber query for {:?}: {}", issis, e);
+                        } else {
+                            tracing::debug!("BrewWorker: sent subscriber query for {:?}", issis);
+                            self.pending_subscriber_queries.push_back(issis);
+                        }
+                    }
                     BrewCommand::Disconnect => {
                         self.graceful_teardown(ws);
                         return Ok(());
@@ -775,11 +801,37 @@ impl BrewWorker {
                     });
                 }
                 BrewMessage::Service(svc) => {
-                    tracing::debug!("BrewWorker: service type={}: {}", svc.service_type, svc.json_data);
+                    self.handle_service(svc);
                 }
             },
             Err(e) => {
                 tracing::warn!("BrewWorker: failed to parse message ({} bytes): {}", data.len(), e);
+            }
+        }
+    }
+
+    fn handle_service(&mut self, svc: BrewServiceMessage) {
+        tracing::debug!("BrewWorker: service type={}: {}", svc.service_type, svc.json_data);
+
+        match svc.service_type {
+            2 => {
+                let Some(queried_issis) = self.pending_subscriber_queries.pop_front() else {
+                    tracing::warn!("BrewWorker: unsolicited subscriber profile response: {}", svc.json_data);
+                    return;
+                };
+
+                let profiles = match parse_subscriber_profiles(&svc.json_data) {
+                    Ok(profiles) => profiles,
+                    Err(e) => {
+                        tracing::warn!("BrewWorker: failed to parse subscriber profile response: {}", e);
+                        HashMap::new()
+                    }
+                };
+
+                let _ = self.event_sender.send(BrewEvent::SubscriberProfiles { queried_issis, profiles });
+            }
+            other => {
+                tracing::debug!("BrewWorker: unhandled service type {}", other);
             }
         }
     }
@@ -917,5 +969,114 @@ impl BrewWorker {
                 tracing::debug!("BrewWorker: unhandled frame type {} uuid={}", ft, frame.identifier);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam_channel::unbounded;
+    use tetra_config::bluestation::{
+        CfgBrew, CfgCellInfo, CfgNetInfo, CfgPhyIo, PhyBackend, SharedConfig, StackConfig, StackMode, StackState,
+    };
+    use tetra_core::ranges::SortedDisjointSsiRanges;
+
+    use super::*;
+
+    fn test_config() -> SharedConfig {
+        SharedConfig::from_parts(
+            StackConfig {
+                stack_mode: StackMode::Bs,
+                debug_log: None,
+                phy_io: CfgPhyIo {
+                    backend: PhyBackend::None,
+                    dl_tx_file: None,
+                    ul_rx_file: None,
+                    ul_input_file: None,
+                    dl_input_file: None,
+                    soapysdr: None,
+                },
+                net: CfgNetInfo { mcc: 204, mnc: 1337 },
+                cell: CfgCellInfo {
+                    colour_code: 1,
+                    location_area: 2,
+                    main_carrier: 1521,
+                    freq_band: 4,
+                    freq_offset_hz: 0,
+                    duplex_spacing_id: 4,
+                    custom_duplex_spacing: None,
+                    reverse_operation: false,
+                    neighbor_cell_broadcast: 0,
+                    late_entry_supported: false,
+                    subscriber_class: 65535,
+                    registration: true,
+                    deregistration: true,
+                    priority_cell: false,
+                    no_minimum_mode: false,
+                    migration: false,
+                    system_wide_services: true,
+                    voice_service: true,
+                    circuit_mode_data_service: false,
+                    sndcp_service: false,
+                    aie_service: false,
+                    advanced_link: false,
+                    system_code: 3,
+                    sharing_mode: 0,
+                    ts_reserved_frames: 0,
+                    u_plane_dtx: false,
+                    frame_18_ext: false,
+                    local_ssi_ranges: SortedDisjointSsiRanges::from_vec_ssirange(vec![]),
+                },
+                brew: Some(CfgBrew {
+                    host: "test.local".into(),
+                    port: 3000,
+                    tls: false,
+                    username: None,
+                    password: None,
+                    reconnect_delay: Duration::from_secs(1),
+                    jitter_initial_latency_frames: 0,
+                    feature_sds_enabled: true,
+                    whitelisted_ssis: None,
+                }),
+            },
+            StackState::default(),
+        )
+    }
+
+    #[test]
+    fn test_handle_service_subscriber_profiles_uses_pending_query_context() {
+        let (event_sender, event_receiver) = unbounded();
+        let (_command_sender, command_receiver) = unbounded();
+        let mut worker = BrewWorker::new(test_config(), event_sender, command_receiver);
+        worker.pending_subscriber_queries.push_back(vec![1_234_567]);
+
+        worker.handle_service(BrewServiceMessage {
+            service_type: 2,
+            json_data: r#"{"1234567":{"status":1}}"#.into(),
+        });
+
+        let BrewEvent::SubscriberProfiles { queried_issis, profiles } = event_receiver.try_recv().unwrap() else {
+            panic!("expected subscriber profile event");
+        };
+        assert_eq!(queried_issis, vec![1_234_567]);
+        assert_eq!(profiles.get(&1_234_567).and_then(|profile| profile.status), Some(1));
+    }
+
+    #[test]
+    fn test_handle_service_invalid_profiles_yields_empty_profile_map() {
+        let (event_sender, event_receiver) = unbounded();
+        let (_command_sender, command_receiver) = unbounded();
+        let mut worker = BrewWorker::new(test_config(), event_sender, command_receiver);
+        worker.pending_subscriber_queries.push_back(vec![1_234_567]);
+
+        worker.handle_service(BrewServiceMessage {
+            service_type: 2,
+            json_data: r#"{"not-an-issi":{"status":1}}"#.into(),
+        });
+
+        let BrewEvent::SubscriberProfiles { queried_issis, profiles } = event_receiver.try_recv().unwrap() else {
+            panic!("expected subscriber profile event");
+        };
+        assert_eq!(queried_issis, vec![1_234_567]);
+        assert!(profiles.is_empty());
     }
 }

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -73,10 +73,8 @@ impl SdsBsSubentity {
         } else if is_local_group {
             tracing::info!("SDS: group delivery: {} -> GSSI {}", source_ssi, dest_ssi);
             self.send_d_sds_data(queue, message.dltime, source_ssi, dest_ssi, SsiType::Gssi, pdu.user_defined_data);
-        } else if brew::feature_sds_enabled(&self.config)
-            && (brew::is_brew_issi_routable(&self.config, dest_ssi) || brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi))
-        {
-            tracing::info!("SDS: forwarding to Brew: {} -> {}", source_ssi, dest_ssi);
+        } else if brew::feature_sds_enabled(&self.config) {
+            tracing::info!("SDS: queueing Brew presence check: {} -> {}", source_ssi, dest_ssi);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
@@ -89,7 +87,7 @@ impl SdsBsSubentity {
                 }),
             });
         } else {
-            tracing::warn!("SDS: dest SSI {} not local and not Brew-routable, dropping", dest_ssi);
+            tracing::warn!("SDS: dest SSI {} not local and Brew SDS is unavailable, dropping", dest_ssi);
         }
     }
 
@@ -164,9 +162,7 @@ impl SdsBsSubentity {
         if self.config.state_read().subscribers.is_registered(dest_ssi) {
             tracing::info!("SDS-STATUS: local delivery: {} -> {}", source_ssi, dest_ssi);
             self.send_d_status(queue, message.dltime, source_ssi, dest_ssi, pdu.pre_coded_status);
-        } else if brew::is_active(&self.config)
-            && (brew::is_brew_issi_routable(&self.config, dest_ssi) || brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi))
-        {
+        } else if brew::feature_sds_enabled(&self.config) {
             // Brew forwarding only: when the pre-coded status carries an SDS-TL short report
             // (ETSI 29.4.2.3), convert it to a full SDS-TL REPORT PDU (Type4) so the
             // remote end recognizes it as a delivery confirmation. ETSI 29.3.3.4.4
@@ -194,7 +190,7 @@ impl SdsBsSubentity {
                 SdsUserData::Type1(pdu.pre_coded_status.into_raw())
             };
 
-            tracing::info!("SDS-STATUS: forwarding to Brew: {} -> {}", source_ssi, dest_ssi);
+            tracing::info!("SDS-STATUS: queueing Brew presence check: {} -> {}", source_ssi, dest_ssi);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
@@ -208,7 +204,7 @@ impl SdsBsSubentity {
             });
         } else {
             tracing::warn!(
-                "SDS-STATUS: dest ISSI {} not locally registered and not Brew-routable, dropping",
+                "SDS-STATUS: dest ISSI {} not locally registered and Brew SDS is unavailable, dropping",
                 dest_ssi
             );
         }

--- a/crates/tetra-entities/tests/test_sds_bs.rs
+++ b/crates/tetra-entities/tests/test_sds_bs.rs
@@ -145,6 +145,46 @@ fn test_sds_brew_forward() {
 }
 
 #[test]
+fn test_sds_nonlocal_service_issi_still_forwarded_for_brew_presence_check() {
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.brew = Some(CfgBrew {
+        host: "core.tetrapack.online".into(),
+        port: 3000,
+        tls: false,
+        username: None,
+        password: None,
+        reconnect_delay: Duration::from_secs(1),
+        jitter_initial_latency_frames: 0,
+        feature_sds_enabled: true,
+        whitelisted_ssis: None,
+    });
+    let mut test = ComponentTest::from_config(config, Some(dltime));
+
+    let components = vec![TetraEntity::Cmce];
+    let sinks = vec![TetraEntity::Mle, TetraEntity::Brew];
+    test.populate_entities(components, sinks);
+
+    let msg = build_u_sds_data_msg(dltime, 1_000_001, 200_999, 0x1234);
+    test.submit_message(msg);
+    test.run_stack(Some(1));
+
+    let sink_msgs = test.dump_sinks();
+    assert_eq!(
+        count_brew_sds(&sink_msgs),
+        1,
+        "Expected Brew routing check for non-local service ISSI"
+    );
+    assert_eq!(
+        count_d_sds_data(&sink_msgs),
+        0,
+        "Should not deliver locally when service ISSI is not registered"
+    );
+}
+
+#[test]
 fn test_sds_from_brew_to_local() {
     debug::setup_logging_verbose();
 
@@ -391,6 +431,77 @@ fn test_u_status_brew_forward() {
     // Should NOT deliver locally
     let d_sds_count = count_d_sds_data(&sink_msgs);
     assert_eq!(d_sds_count, 0, "Should not deliver locally when dest is not registered");
+}
+
+#[test]
+fn test_u_status_nonlocal_service_issi_still_forwarded_for_brew_presence_check() {
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.brew = Some(CfgBrew {
+        host: "core.tetrapack.online".into(),
+        port: 3000,
+        tls: false,
+        username: None,
+        password: None,
+        reconnect_delay: Duration::from_secs(1),
+        jitter_initial_latency_frames: 0,
+        feature_sds_enabled: true,
+        whitelisted_ssis: None,
+    });
+    let mut test = ComponentTest::from_config(config, Some(dltime));
+
+    let components = vec![TetraEntity::Cmce];
+    let sinks = vec![TetraEntity::Mle, TetraEntity::Brew];
+    test.populate_entities(components, sinks);
+
+    register_subscriber(&mut test, 1_000_001);
+
+    let u_status = UStatus {
+        area_selection: 0,
+        called_party_type_identifier: PartyTypeIdentifier::Ssi,
+        called_party_short_number_address: None,
+        called_party_ssi: Some(200_999),
+        called_party_extension: None,
+        pre_coded_status: PreCodedStatus::from(0x8210),
+        external_subscriber_number: None,
+        dm_ms_address: None,
+    };
+
+    let mut sdu = BitBuffer::new_autoexpand(80);
+    u_status.to_bitbuf(&mut sdu).expect("Failed to serialize U-STATUS");
+    sdu.seek(0);
+
+    let msg = SapMsg {
+        sap: Sap::LcmcSap,
+        src: TetraEntity::Mle,
+        dest: TetraEntity::Cmce,
+        dltime,
+        msg: SapMsgInner::LcmcMleUnitdataInd(LcmcMleUnitdataInd {
+            sdu,
+            handle: 1,
+            endpoint_id: 1,
+            link_id: 1,
+            received_tetra_address: TetraAddress::new(1_000_001, SsiType::Issi),
+            chan_change_resp_req: false,
+            chan_change_handle: None,
+        }),
+    };
+    test.submit_message(msg);
+    test.run_stack(Some(1));
+
+    let sink_msgs = test.dump_sinks();
+    assert_eq!(
+        count_brew_sds(&sink_msgs),
+        1,
+        "Expected Brew routing check for non-local service U-STATUS"
+    );
+    assert_eq!(
+        count_d_sds_data(&sink_msgs),
+        0,
+        "Should not deliver locally when service ISSI is not registered"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the hardcoded TetraPack SDS service ISSI whitelist
- route non-local SDS and SDS-STATUS through a Brew subscriber presence query
- only forward SDS to Brew when the returned subscriber profile has `status == 1`
- drop unroutable destinations with an explicit log message

## Details
This changes SDS routing from a fixed ISSI allowlist to a Brew-driven presence check.

Local ISSI and local GSSI handling are unchanged.
For non-local ISSIs, CMCE now hands the message to Brew, Brew sends a `0xf4` service query, and queued SDS is only released when the matching subscriber profile response reports `status: 1`.

If no routable external subscriber is confirmed, the message is dropped with:
`ISSI (<number>) is not Routeable Locally or Externally, Dropping`

## Validation
- `cargo fmt --all`
- `cargo test -p tetra-entities --lib -- --nocapture`
- `cargo test -p tetra-entities --test test_sds_bs -- --nocapture`
