### PR TITLE
Fix: SDS U-STATUS General Status Acknowledgements

### DIFF
--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -63,16 +63,21 @@ impl SdsBsSubentity {
         let dest_ssi = pdu.called_party_ssi.unwrap() as u32;
         let source_ssi = calling_party.ssi;
 
-        tracing::info!(
-            "SDS: U-SDS-DATA from ISSI {} to ISSI {}, type={}",
-            source_ssi,
-            dest_ssi,
-            pdu.user_defined_data.type_identifier()
-        );
-
         // Route: local delivery (ISSI or GSSI), Brew forward, or drop
         let is_local_issi = self.config.state_read().subscribers.is_registered(dest_ssi);
         let is_local_group = !is_local_issi && self.config.state_read().subscribers.has_group_members(dest_ssi);
+        let is_brew_routable = net_brew::is_active(&self.config) && (
+            net_brew::is_brew_issi_routable(&self.config, dest_ssi) ||
+            net_brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi)
+        );
+
+        tracing::info!(
+            "SDS: U-SDS-DATA from ISSI {} to {} {}, type={}",
+            source_ssi,
+            if is_local_group { "GSSI" } else if is_local_issi { "ISSI" } else if is_brew_routable { "Brew-routable ISSI" } else { "Unknown SSI" },
+            dest_ssi,
+            pdu.user_defined_data.type_identifier()
+        );
 
         if is_local_issi {
             tracing::info!("SDS: local delivery: {} -> {}", source_ssi, dest_ssi);
@@ -80,9 +85,7 @@ impl SdsBsSubentity {
         } else if is_local_group {
             tracing::info!("SDS: group delivery: {} -> GSSI {}", source_ssi, dest_ssi);
             self.send_d_sds_data(queue, message.dltime, source_ssi, dest_ssi, SsiType::Gssi, pdu.user_defined_data);
-        } else if net_brew::feature_sds_enabled(&self.config)
-            && (net_brew::is_brew_issi_routable(&self.config, dest_ssi) || net_brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi))
-        {
+        } else if is_brew_routable {
             tracing::info!("SDS: forwarding to Brew: {} -> {}", source_ssi, dest_ssi);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
@@ -100,10 +103,6 @@ impl SdsBsSubentity {
             return;
         }
 
-        // The U-STATUS has been forwarded (as far as we know), so confirm receipt with a D-STATUS
-        // TODO For individual destinations, we could use the L2 ACK as confirmation and only send this D-STATUS on confirmed success
-        // TODO For group destinations, there is no L2 ACK, so we'd just have to send this anyway.
-        self.send_d_status(queue, message.dltime, SWMI_SSI_ADDRESS, source_ssi, D_STATUS_PRE_CODED_GENERAL_STATUS_ACKNOWLEDGEMENT);
     }
 
     /// Handle incoming SDS data from Brew entity (network-originated SDS)
@@ -150,17 +149,20 @@ impl SdsBsSubentity {
             panic!("Expected SendSds command");
         };
 
+        let dest_type_name = dest_is_group.then(|| "GSSI").unwrap_or("ISSI");
+
         tracing::info!(
             "SDS: received from Control {}: {} -> {}, type={}, {} bits",
             handle,
             source_ssi,
             dest_ssi,
-            dest_is_group.then(|| "GSSI").unwrap_or("ISSI"),
+            dest_type_name,
             len_bits
         );
 
         if !self.config.state_read().subscribers.is_registered(dest_ssi) {
-            tracing::warn!("SDS: dest ISSI {} from Control is not locally registered, dropping", dest_ssi);
+            tracing::warn!(
+                "SDS: dest {} {} from Control is not locally registered, dropping", dest_type_name,  dest_ssi);
             return false;
         }
 
@@ -206,20 +208,30 @@ impl SdsBsSubentity {
         let dest_ssi = pdu.called_party_ssi.unwrap() as u32;
         let source_ssi = calling_party.ssi;
 
+        // Route: local delivery (ISSI or GSSI), Brew forward, or drop
+        let is_local_issi = self.config.state_read().subscribers.is_registered(dest_ssi);
+        let is_local_group = !is_local_issi && self.config.state_read().subscribers.has_group_members(dest_ssi);
+        let is_brew_routable = net_brew::is_active(&self.config) && (
+            net_brew::is_brew_issi_routable(&self.config, dest_ssi) ||
+            net_brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi)
+        );
+
         tracing::info!(
-            "SDS: U-STATUS from ISSI {} to ISSI {}, status={}",
+            "SDS: U-STATUS from ISSI {} to {} {}, status={}",
             source_ssi,
+            if is_local_group { "GSSI" } else if is_local_issi { "ISSI" } else if is_brew_routable { "Brew-routable ISSI" } else { "Unknown SSI" },
             dest_ssi,
             pdu.pre_coded_status
         );
 
         // Route: local delivery, Brew forward, or drop
-        if self.config.state_read().subscribers.is_registered(dest_ssi) {
+        if is_local_issi {
             tracing::info!("SDS-STATUS: local delivery: {} -> {}", source_ssi, dest_ssi);
             self.send_d_status(queue, message.dltime, source_ssi, dest_ssi, pdu.pre_coded_status);
-        } else if net_brew::is_active(&self.config)
-            && (net_brew::is_brew_issi_routable(&self.config, dest_ssi) || net_brew::is_tetrapack_sds_service_issi(&self.config, dest_ssi))
-        {
+        } else if is_local_group {
+            tracing::info!("SDS-STATUS: group delivery: {} -> GSSI {}", source_ssi, dest_ssi);
+            self.send_d_status(queue, message.dltime, source_ssi, dest_ssi, pdu.pre_coded_status);
+        } else if is_brew_routable {
             // Brew forwarding only: when the pre-coded status carries an SDS-TL short report
             // (ETSI 29.4.2.3), convert it to a full SDS-TL REPORT PDU (Type4) so the
             // remote end recognizes it as a delivery confirmation. ETSI 29.3.3.4.4
@@ -259,12 +271,20 @@ impl SdsBsSubentity {
                     user_defined_data,
                 }),
             });
+
         } else {
             tracing::warn!(
-                "SDS-STATUS: dest ISSI {} not locally registered and not Brew-routable, dropping",
+                "SDS-STATUS: dest SSI {} not locally registered and not Brew-routable, dropping",
                 dest_ssi
             );
+            return;
         }
+
+        // The U-STATUS has been forwarded (as far as we know), so confirm receipt with a D-STATUS
+        // TODO For individual destinations, we could use the L2 ACK as confirmation and only send this D-STATUS on confirmed success
+        // TODO For group destinations, there is no L2 ACK, so we'd just have to send this anyway.
+        tracing::info!("SDS: sending general status acknowledgement to {}", source_ssi);
+        self.send_d_status(queue, message.dltime, SWMI_SSI_ADDRESS, source_ssi, D_STATUS_PRE_CODED_GENERAL_STATUS_ACKNOWLEDGEMENT);
     }
 
     /// Build and send a D-STATUS PDU to a local MS

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -9,6 +9,7 @@ use tetra_saps::lcmc::LcmcMleUnitdataReq;
 use tetra_saps::{SapMsg, SapMsgInner};
 
 use tetra_pdus::cmce::enums::party_type_identifier::PartyTypeIdentifier;
+use tetra_pdus::cmce::enums::pre_coded_status::PreCodedStatus::NetworkUserSpecific;
 use tetra_pdus::cmce::pdus::d_sds_data::DSdsData;
 use tetra_pdus::cmce::pdus::d_status::DStatus;
 use tetra_pdus::cmce::pdus::u_sds_data::USdsData;
@@ -17,6 +18,11 @@ use tetra_pdus::cmce::pdus::u_status::UStatus;
 use crate::MessageQueue;
 use crate::net_brew;
 use crate::net_control::ControlCommand;
+
+/// Defined as part of the TETRA Interoperability Profile (TIP)
+/// https://tcca.info/documents/TTR001-01_v700_Core.pdf
+const SWMI_SSI_ADDRESS: u32 = 0xFFFFFD;
+const D_STATUS_PRE_CODED_GENERAL_STATUS_ACKNOWLEDGEMENT: PreCodedStatus = NetworkUserSpecific(0xFE00);
 
 /// Clause 13 Short Data Service CMCE sub-entity
 pub struct SdsBsSubentity {
@@ -91,7 +97,13 @@ impl SdsBsSubentity {
             });
         } else {
             tracing::warn!("SDS: dest SSI {} not local and not Brew-routable, dropping", dest_ssi);
+            return;
         }
+
+        // The U-STATUS has been forwarded (as far as we know), so confirm receipt with a D-STATUS
+        // TODO For individual destinations, we could use the L2 ACK as confirmation and only send this D-STATUS on confirmed success
+        // TODO For group destinations, there is no L2 ACK, so we'd just have to send this anyway.
+        self.send_d_status(queue, message.dltime, SWMI_SSI_ADDRESS, source_ssi, D_STATUS_PRE_CODED_GENERAL_STATUS_ACKNOWLEDGEMENT);
     }
 
     /// Handle incoming SDS data from Brew entity (network-originated SDS)
@@ -192,7 +204,6 @@ impl SdsBsSubentity {
 
         // Extract destination SSI (guaranteed present after feature check)
         let dest_ssi = pdu.called_party_ssi.unwrap() as u32;
-
         let source_ssi = calling_party.ssi;
 
         tracing::info!(

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -23,6 +23,7 @@ use crate::net_control::ControlCommand;
 /// https://tcca.info/documents/TTR001-01_v700_Core.pdf
 const SWMI_SSI_ADDRESS: u32 = 0xFFFFFD;
 const D_STATUS_PRE_CODED_GENERAL_STATUS_ACKNOWLEDGEMENT: PreCodedStatus = NetworkUserSpecific(0xFE00);
+const D_STATUS_PRE_CODED_GENERAL_STATUS_NEGATIVE_ACKNOWLEDGEMENT: PreCodedStatus = NetworkUserSpecific(0xFE01);
 
 /// Clause 13 Short Data Service CMCE sub-entity
 pub struct SdsBsSubentity {
@@ -273,10 +274,15 @@ impl SdsBsSubentity {
             });
 
         } else {
+
             tracing::warn!(
                 "SDS-STATUS: dest SSI {} not locally registered and not Brew-routable, dropping",
                 dest_ssi
             );
+
+            tracing::info!("SDS: sending general status negative acknowledgement to {}", source_ssi);
+            self.send_d_status(queue, message.dltime, SWMI_SSI_ADDRESS, source_ssi, D_STATUS_PRE_CODED_GENERAL_STATUS_NEGATIVE_ACKNOWLEDGEMENT);
+
             return;
         }
 


### PR DESCRIPTION
This change adds [TIP (TETRA Interoperability Profile)](https://tcca.info/documents/TTR001-01_v700_Core.pdf/)-compliant `D-STATUS` acknowledgements sent in response to `U-STATUS` messages. 

Most (all?) MSs seem to send `U-STATUS` over the unack'd LLC service. If they don't receive a General Status Acknowledgement, they'll sit re-sending the `U-STATUS` message up to some counter value (5 or 10 seems common) then showing "Status Failed" or similar on the MMI. This change resolves that by sending the General Status Acknowledgement pre-coded status (`FFFFFD`) to the calling MS from the reserved SwMI SSI (`FE00`). Similarly, where a status destination is not routable or locally available, the General Status Negative Acknowledgement pre-coded status (`FE01`) will be sent.

Improvements could be made such that these are only sent for individual-destination `U-STATUS` messages where we receive L2 acknowledgement that delivery took place, but they should (I think) always be sent for group-destination `U-STATUS`.

This change also fixes a few places where the wrong nomenclature was used in trace messages for addresses (ISSI vs GSSI etc).