### PR TITLE
Fix: CMCE CC Late Entry D-SETUP Throttling Behaviour

### DIFF
--- a/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
+++ b/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
@@ -315,6 +315,7 @@ impl CircuitMgr {
                     // Send D-SETUP for the initial frame + 1 backup frame after circuit creation.
                     // Matches ETSI Annex D Figure D.2: 1 initial + 1 back-up on MCCH.
                     if age < frames!(D_SETUP_REPEATS) {
+                        tracing::debug!("CircuitMgr: Sending initial D-SETUP backup for circuit {:?} (age {} frames)", circuit, age);
                         tasks
                             .get_or_insert_with(Vec::new)
                             .push(CircuitMgrCmd::SendDSetup(circuit.call_id, circuit.usage, circuit.ts));
@@ -323,6 +324,7 @@ impl CircuitMgr {
                     // Compare in frames (age/4) since tick_start only fires on t==1
                     // but ts_created may have any timeslot value.
                     else if (age / 4) % (LATE_ENTRY_INTERVAL_TIMESLOTS / 4) == 0 {
+                        tracing::debug!("CircuitMgr: Sending late-entry D-SETUP for circuit {:?} (age {} frames)", circuit, age);
                         tasks
                             .get_or_insert_with(Vec::new)
                             .push(CircuitMgrCmd::SendDSetup(circuit.call_id, circuit.usage, circuit.ts));

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs.rs
@@ -700,7 +700,10 @@ impl CcBsSubentity {
                         let (sdu, chan_alloc) = Self::build_d_setup_prim(pdu, usage, ts, UlDlAssignment::Both);
 
                         // Create a fresh txreporter for this re-send
-                        let reporter = TxReporter::new();
+                        let reporter = TxReporter::new_unacked();
+
+                        // Cache the setup in cached_setups with the reporter so we can check its state on the next tick and throttle if it's still pending in UMAC
+                        *receipt = Some(reporter.clone());
 
                         let prim = Self::build_sapmsg(
                             sdu,


### PR DESCRIPTION
Fixes the CMCE CC behaviour to throttle late-entry `D-SETUP` PDUs from being sent while a previous late entry `D-SETUP` PDU for the call is still `Pending` (waiting to be transmitted by the MAC).

Just a minor mix-up with the ack/unack aspect and the `D-SETUP`s & their receipts were never being cached. This fixes the `test_dsetup_late_entry_throttle` test too.