### PR TITLE
Fix: Incorrect entity used in MS mode during tests caused multiple test failures

### DIFF
--- a/crates/tetra-entities/src/mle/mle_ms.rs
+++ b/crates/tetra-entities/src/mle/mle_ms.rs
@@ -1,9 +1,8 @@
 use crate::mle::components::mle_router::MleRouter;
-use crate::mle::components::network_time::encode_tetra_network_time;
 use crate::{MessageQueue, TetraEntityTrait};
 use tetra_config::bluestation::SharedConfig;
 use tetra_core::tetra_entities::TetraEntity;
-use tetra_core::{BitBuffer, Sap, SsiType, TdmaTime, TetraAddress, unimplemented_log};
+use tetra_core::{BitBuffer, Sap, unimplemented_log};
 use tetra_saps::lcmc::LcmcMleUnitdataInd;
 use tetra_saps::lmm::LmmMleUnitdataInd;
 use tetra_saps::ltpd::LtpdMleUnitdataInd;
@@ -14,9 +13,9 @@ use tetra_pdus::mle::enums::mle_pdu_type_dl::MlePduTypeDl;
 use tetra_pdus::mle::enums::mle_protocol_discriminator::MleProtocolDiscriminator;
 use tetra_pdus::mle::pdus::d_mle_sync::DMleSync;
 use tetra_pdus::mle::pdus::d_mle_sysinfo::DMleSysinfo;
-use tetra_pdus::mle::pdus::d_nwrk_broadcast::DNwrkBroadcast;
 
 pub struct MleMs {
+    self_component: TetraEntity,
     config: SharedConfig,
     router: MleRouter,
 }
@@ -24,6 +23,7 @@ pub struct MleMs {
 impl MleMs {
     pub fn new(config: SharedConfig) -> Self {
         Self {
+            self_component: TetraEntity::Mle,
             config,
             router: MleRouter::new(),
         }

--- a/crates/tetra-entities/src/mle/mod.rs
+++ b/crates/tetra-entities/src/mle/mod.rs
@@ -1,3 +1,4 @@
 pub mod components;
 
 pub mod mle_bs;
+pub mod mle_ms;

--- a/crates/tetra-entities/tests/common/component_test.rs
+++ b/crates/tetra-entities/tests/common/component_test.rs
@@ -16,6 +16,7 @@ use tetra_entities::umac::umac_bs::UmacBs;
 
 // MS imports
 use tetra_entities::lmac::lmac_ms::LmacMs;
+use tetra_entities::mle::mle_ms::MleMs;
 use tetra_entities::umac::umac_ms::UmacMs;
 
 use crate::common::default_stack;
@@ -149,7 +150,7 @@ impl ComponentTest {
                     self.router.register_entity(Box::new(llc));
                 }
                 TetraEntity::Mle => {
-                    let mle = MleBs::new(self.config.clone());
+                    let mle = MleMs::new(self.config.clone());
                     self.router.register_entity(Box::new(mle));
                 }
                 TetraEntity::Cmce => {


### PR DESCRIPTION
The BS MLE entity was incorrectly used in the MS mode test stack, leading to some errors about the MLE not being able to process broadcasts.

This change, along with #76 fixes the remaining failing tests.