### PR TITLE
Harden AACH parsing and bound is_hangtime

### DIFF
--- a/crates/tetra-entities/src/mle/mle_ms.rs
+++ b/crates/tetra-entities/src/mle/mle_ms.rs
@@ -223,9 +223,9 @@ impl MleMs {
             }
             MleProtocolDiscriminator::Cmce => {
                 tracing::warn!("TM-UNITDATA for MM?"); // todo fixme find if ever used
-                    // let handle = self
-                    //     .router
-                    //     .create_handle(prim.main_address, prim.link_id, prim.endpoint_id, message.dltime);
+                // let handle = self
+                //     .router
+                //     .create_handle(prim.main_address, prim.link_id, prim.endpoint_id, message.dltime);
                 let m = LcmcMleUnitdataInd {
                     sdu,
                     handle: 0, // handle,

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -4,6 +4,13 @@ use tetra_saps::{
     tmv::{TmvUnitdataReq, TmvUnitdataReqSlot, enums::logical_chans::LogicalChannel},
 };
 
+use crate::{
+    lmac::components::scrambler,
+    umac::subcomp::{bs_frag::BsFragger, circuit_mgr::CircuitMgr},
+};
+use tetra_pdus::umac::enums::access_code::AccessCode;
+use tetra_pdus::umac::structs::access_field::AccessField;
+use tetra_pdus::umac::structs::base_frame_length::BaseFrameLength;
 use tetra_pdus::{
     mle::pdus::{d_mle_sync::DMleSync, d_mle_sysinfo::DMleSysinfo},
     umac::{
@@ -14,20 +21,10 @@ use tetra_pdus::{
         },
         fields::basic_slotgrant::BasicSlotgrant,
         pdus::{
-            access_assign::{AccessAssign},
-            access_assign_fr18::AccessAssignFr18,
-            mac_resource::MacResource,
-            mac_sync::MacSync,
+            access_assign::AccessAssign, access_assign_fr18::AccessAssignFr18, mac_resource::MacResource, mac_sync::MacSync,
             mac_sysinfo::MacSysinfo,
         },
     },
-};
-use tetra_pdus::umac::enums::access_code::AccessCode;
-use tetra_pdus::umac::structs::access_field::AccessField;
-use tetra_pdus::umac::structs::base_frame_length::BaseFrameLength;
-use crate::{
-    lmac::components::scrambler,
-    umac::subcomp::{bs_frag::BsFragger, circuit_mgr::CircuitMgr},
 };
 
 /// We submit this many TX timeslots ahead of the current time
@@ -161,6 +158,10 @@ impl BsChannelScheduler {
     }
 
     pub fn is_hangtime(&self, ts: u8) -> bool {
+        if !(1..=4).contains(&ts) {
+            tracing::warn!("BsChannelScheduler::is_hangtime: invalid ts {}", ts);
+            return false;
+        }
         self.hangtime[ts as usize - 1]
     }
 
@@ -624,10 +625,10 @@ impl BsChannelScheduler {
                 i += 1;
             } else {
                 // Found a to-be-discarded element.
-                // Remove, warn, and call tx_reporter::mark_discarded() if appliccable
+                // Remove, log, and call tx_reporter::mark_discarded() if applicable
                 let elem = queue.remove(i);
                 item_was_discarded = true;
-                tracing::warn!("dl_drop_all_except_stolen: discarding scheduled {:?} on ts {}", elem, timeslot);
+                tracing::debug!("dl_drop_all_except_stolen: discarding scheduled {:?} on ts {}", elem, timeslot);
 
                 match elem {
                     DlSchedElem::Resource(_, _, tx_reporter) => {
@@ -1082,7 +1083,6 @@ impl BsChannelScheduler {
     }
 
     fn generate_bbk_block(&self, ts: TdmaTime) -> TmvUnitdataReq {
-
         let (ul_traffic_usage, dl_traffic_usage) = if ts.f == 18 {
             (None, None)
         } else {
@@ -1096,12 +1096,9 @@ impl BsChannelScheduler {
         let mut aach_bb = BitBuffer::new(14);
 
         if ts.f != 18 {
-
             let aach = match ts.t {
-
                 // MCCH (TS1)
                 1 => {
-
                     // 23.3.1.1.2
                     // "During normal mode operation, it shall always be assumed that slot 1 on the
                     // downlink is for common control as part of the MCCH."
@@ -1124,7 +1121,7 @@ impl BsChannelScheduler {
                                 BaseFrameLength::ReservedSubslot
                             } else {
                                 DEFAULT_ACCESS_FRAME_MARKER
-                            }
+                            },
                         },
                         access_field_2: AccessField {
                             access_code: AccessCode::AccessCodeA,
@@ -1132,17 +1129,14 @@ impl BsChannelScheduler {
                                 BaseFrameLength::ReservedSubslot
                             } else {
                                 DEFAULT_ACCESS_FRAME_MARKER
-                            }
+                            },
                         },
                     }
-
-                },
+                }
 
                 // Additional channels (TS2..TS4)
                 2..=4 => {
-
                     if self.is_hangtime(ts.t) && (dl_traffic_usage.is_some() || ul_traffic_usage.is_some()) {
-
                         // Hangtime: immediately switch AACH to AssignedControl so radios
                         // detect the end of traffic in the same frame as D-TX CEASED.
                         // The timeslot may still be in traffic mode (for STCH delivery) but
@@ -1154,9 +1148,7 @@ impl BsChannelScheduler {
                                 base_frame_len: DEFAULT_ACCESS_FRAME_MARKER,
                             },
                         }
-
                     } else {
-
                         // Normal operation: Traffic(usage) when a circuit is active, else Unallocated
                         AccessAssign::DownlinkDefinedUplinkDefined {
                             downlink_usage_marker: if let Some(usage) = dl_traffic_usage {
@@ -1168,19 +1160,16 @@ impl BsChannelScheduler {
                                 AccessAssignUlUsage::Traffic(usage)
                             } else {
                                 AccessAssignUlUsage::Unallocated
-                            }
+                            },
                         }
-
                     }
-                },
+                }
 
-                _ => panic!("finalize_ts_for_tick: invalid timeslot {}", ts.t)
+                _ => panic!("finalize_ts_for_tick: invalid timeslot {}", ts.t),
             };
 
             aach.to_bitbuf(&mut aach_bb);
-
         } else {
-
             // Frame 18 is the Control Frame, which cannot contain traffic
             assert!(ul_traffic_usage.is_none() && dl_traffic_usage.is_none());
 
@@ -1195,15 +1184,15 @@ impl BsChannelScheduler {
                         BaseFrameLength::CLCHSubslot
                     } else {
                         DEFAULT_ACCESS_FRAME_MARKER
-                    }
+                    },
                 },
                 access_field_2: AccessField {
                     access_code: AccessCode::AccessCodeA,
                     base_frame_len: if self.ul_get_slot_owner(ts, PhyBlockNum::Block2).is_some() {
                         BaseFrameLength::ReservedSubslot
-                     } else {
+                    } else {
                         DEFAULT_ACCESS_FRAME_MARKER
-                    }
+                    },
                 },
             };
 
@@ -1580,7 +1569,6 @@ mod tests {
 
     #[test]
     fn test_dl_indicates_reserved_subslots() {
-
         let mut sched = get_testing_slotter();
         let mut ts = TdmaTime::default();
 
@@ -1597,8 +1585,7 @@ mod tests {
             aach_buf.seek(0);
 
             // Decode the AACH (which in this test will always be the F1-17 format)
-            let access_assign = AccessAssign::from_bitbuf(&mut aach_buf)
-                .expect("Failed to decode AACH block");
+            let access_assign = AccessAssign::from_bitbuf(&mut aach_buf).expect("Failed to decode AACH block");
             tracing::debug!("Decoded AACH: {:?}", access_assign);
 
             // Third occurrence should have both slots reserved
@@ -1609,18 +1596,23 @@ mod tests {
             };
 
             match access_assign {
-                AccessAssign::DownlinkCommonControlUplinkCommonOnly { access_field_1, access_field_2 } => {
+                AccessAssign::DownlinkCommonControlUplinkCommonOnly {
+                    access_field_1,
+                    access_field_2,
+                } => {
                     assert_eq!(
-                        access_field_1.base_frame_len, expected_subslot_bfl,
+                        access_field_1.base_frame_len,
+                        expected_subslot_bfl,
                         "Unexpected base frame length for access field 1 on TS1 occurrence {}",
                         i + 1
                     );
                     assert_eq!(
-                        access_field_2.base_frame_len, expected_subslot_bfl,
+                        access_field_2.base_frame_len,
+                        expected_subslot_bfl,
                         "Unexpected base frame length for access field 2 on TS1 occurrence {}",
                         i + 1
                     );
-                },
+                }
                 _ => panic!("Expected DownlinkCommonControlUplinkCommonOnly format for TS1"),
             }
 
@@ -1634,23 +1626,16 @@ mod tests {
         let sched = get_testing_slotter();
 
         // Frame 18
-        let mut ts = TdmaTime {
-            t: 1,
-            f: 18,
-            m: 1,
-            h: 0,
-        };
+        let mut ts = TdmaTime { t: 1, f: 18, m: 1, h: 0 };
 
         // Generate the next 4 frames to make sure CLCH is correctly indicated
         for _ in 0..4 {
-
             let bbk = sched.generate_bbk_block(ts);
             let mut aach_buf = bbk.mac_block.clone();
             aach_buf.seek(0);
 
             // Decode the AACH (which in this test will always be the frame 18 format)
-            let access_assign = AccessAssignFr18::from_bitbuf(&mut aach_buf)
-                .expect("Failed to decode AACH block");
+            let access_assign = AccessAssignFr18::from_bitbuf(&mut aach_buf).expect("Failed to decode AACH block");
             tracing::debug!("Decoded AACH: {:?}", access_assign);
 
             // For MN=1, F=18, T=2, SSN1 should be CLCH (when F == 18 and T == 4 - ((M + 1) % 4), otherwise default
@@ -1666,12 +1651,11 @@ mod tests {
                         access_field_1.base_frame_len, expected_subslot_bfl,
                         "Unexpected base frame length for access field 1 on frame 18"
                     );
-                },
+                }
                 _ => panic!("Expected AccessAssignFr18::UplinkCommonOnly format for frame 18"),
             }
 
             ts = ts.add_timeslots(1);
         }
     }
-
 }

--- a/crates/tetra-pdus/src/umac/pdus/access_assign.rs
+++ b/crates/tetra-pdus/src/umac/pdus/access_assign.rs
@@ -1,21 +1,20 @@
+pub(crate) use crate::umac::enums::access_code::AccessCode;
+use crate::umac::enums::{access_assign_dl_usage::AccessAssignDlUsage, access_assign_ul_usage::AccessAssignUlUsage};
+pub(crate) use crate::umac::structs::access_field::AccessField;
+pub(crate) use crate::umac::structs::base_frame_length::BaseFrameLength;
 use core::fmt;
 use std::panic;
 use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
-use crate::umac::enums::{access_assign_dl_usage::AccessAssignDlUsage, access_assign_ul_usage::AccessAssignUlUsage};
-pub(crate) use crate::umac::enums::access_code::AccessCode;
-pub(crate) use crate::umac::structs::access_field::AccessField;
-pub(crate) use crate::umac::structs::base_frame_length::BaseFrameLength;
 
 /// Clause 21.4.7.2 ACCESS-ASSIGN
 #[derive(Debug)]
 pub enum AccessAssign {
-
     // Header = 00
     // Downlink usage - common control
     // Uplink access rights - common only
     DownlinkCommonControlUplinkCommonOnly {
         access_field_1: AccessField,
-        access_field_2: AccessField
+        access_field_2: AccessField,
     },
 
     // Header = 01
@@ -23,7 +22,7 @@ pub enum AccessAssign {
     // Uplink access rights - common and assigned
     DownlinkDefinedUplinkCommonAndAssigned {
         downlink_usage_marker: AccessAssignDlUsage,
-        access_field: AccessField
+        access_field: AccessField,
     },
 
     // Header = 10
@@ -31,7 +30,7 @@ pub enum AccessAssign {
     // Uplink access rights - assigned only
     DownlinkDefinedUplinkAssignedOnly {
         downlink_usage_marker: AccessAssignDlUsage,
-        access_field: AccessField
+        access_field: AccessField,
     },
 
     // Header = 11
@@ -39,9 +38,8 @@ pub enum AccessAssign {
     // Uplink access rights - defined by field 2
     DownlinkDefinedUplinkDefined {
         downlink_usage_marker: AccessAssignDlUsage,
-        uplink_usage_marker: AccessAssignUlUsage
-    }
-
+        uplink_usage_marker: AccessAssignUlUsage,
+    },
 }
 
 impl Default for AccessAssign {
@@ -49,45 +47,44 @@ impl Default for AccessAssign {
         AccessAssign::DownlinkCommonControlUplinkCommonOnly {
             access_field_1: AccessField {
                 access_code: AccessCode::AccessCodeA,
-                base_frame_len: BaseFrameLength::Subslots4
+                base_frame_len: BaseFrameLength::Subslots4,
             },
             access_field_2: AccessField {
                 access_code: AccessCode::AccessCodeA,
-                base_frame_len: BaseFrameLength::Subslots4
-             }
+                base_frame_len: BaseFrameLength::Subslots4,
+            },
         }
     }
 }
 
 impl AccessAssign {
-
     pub fn dl_is_traffic(&self) -> bool {
         match self {
-            AccessAssign::DownlinkDefinedUplinkCommonAndAssigned { downlink_usage_marker, .. } |
-            AccessAssign::DownlinkDefinedUplinkAssignedOnly { downlink_usage_marker, .. } |
-            AccessAssign::DownlinkDefinedUplinkDefined { downlink_usage_marker, .. } => {
-                downlink_usage_marker.is_traffic()
-            },
-            _ => false
+            AccessAssign::DownlinkDefinedUplinkCommonAndAssigned { downlink_usage_marker, .. }
+            | AccessAssign::DownlinkDefinedUplinkAssignedOnly { downlink_usage_marker, .. }
+            | AccessAssign::DownlinkDefinedUplinkDefined { downlink_usage_marker, .. } => downlink_usage_marker.is_traffic(),
+            _ => false,
         }
     }
 
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-
         let header = buf.read_field(2, "_header")?;
         let field1 = buf.read_field(6, "field1")?;
         let field2 = buf.read_field(6, "field2")?;
 
         match header {
-
             0b00 => {
                 // Downlink usage - common control
                 // Uplink access rights - common only
                 Ok(AccessAssign::DownlinkCommonControlUplinkCommonOnly {
-                    access_field_1: field1.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_1", value: field1 })?,
-                    access_field_2: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_2", value: field2 })?,
+                    access_field_1: field1.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_1",
+                        value: field1,
+                    })?,
+                    access_field_2: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_2",
+                        value: field2,
+                    })?,
                 })
             }
 
@@ -96,8 +93,10 @@ impl AccessAssign {
                 // Uplink access rights - common and assigned
                 Ok(AccessAssign::DownlinkDefinedUplinkCommonAndAssigned {
                     downlink_usage_marker: AccessAssignDlUsage::from_usage_marker(field1 as u8),
-                    access_field: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field", value: field2 })?,
+                    access_field: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field",
+                        value: field2,
+                    })?,
                 })
             }
 
@@ -106,8 +105,10 @@ impl AccessAssign {
                 // Uplink access rights - assigned only
                 Ok(AccessAssign::DownlinkDefinedUplinkAssignedOnly {
                     downlink_usage_marker: AccessAssignDlUsage::from_usage_marker(field1 as u8),
-                    access_field: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field", value: field2 })?,
+                    access_field: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field",
+                        value: field2,
+                    })?,
                 })
             }
 
@@ -116,7 +117,10 @@ impl AccessAssign {
                 // Uplink access rights - defined by field 2
                 Ok(AccessAssign::DownlinkDefinedUplinkDefined {
                     downlink_usage_marker: AccessAssignDlUsage::from_usage_marker(field1 as u8),
-                    uplink_usage_marker: AccessAssignUlUsage::from_usage_marker(field2 as u8).unwrap(),
+                    uplink_usage_marker: AccessAssignUlUsage::from_usage_marker(field2 as u8).ok_or(PduParseErr::InvalidValue {
+                        field: "uplink_usage_marker",
+                        value: field2,
+                    })?,
                 })
             }
 
@@ -127,14 +131,11 @@ impl AccessAssign {
     }
 
     pub fn to_bitbuf(&self, buf: &mut BitBuffer) {
-
         match self {
-
             AccessAssign::DownlinkCommonControlUplinkCommonOnly {
                 access_field_1,
-                access_field_2
+                access_field_2,
             } => {
-
                 // Header = 00
                 buf.write_bits(0b00, 2);
 
@@ -143,14 +144,12 @@ impl AccessAssign {
 
                 // Access field 2
                 buf.write_bits(access_field_2.into_raw(), 6);
-
-            },
+            }
 
             AccessAssign::DownlinkDefinedUplinkCommonAndAssigned {
                 downlink_usage_marker,
-                access_field
+                access_field,
             } => {
-
                 // Header = 01
                 buf.write_bits(0b01, 2);
 
@@ -159,14 +158,12 @@ impl AccessAssign {
 
                 // Access field (both subslots)
                 buf.write_bits(access_field.into_raw(), 6);
-
-            },
+            }
 
             AccessAssign::DownlinkDefinedUplinkAssignedOnly {
                 downlink_usage_marker,
-                access_field
+                access_field,
             } => {
-
                 // Header = 10
                 buf.write_bits(0b10, 2);
 
@@ -175,14 +172,12 @@ impl AccessAssign {
 
                 // Access field (both subslots)
                 buf.write_bits(access_field.into_raw(), 6);
-
-            },
+            }
 
             AccessAssign::DownlinkDefinedUplinkDefined {
                 downlink_usage_marker,
-                uplink_usage_marker
+                uplink_usage_marker,
             } => {
-
                 // Header = 11
                 buf.write_bits(0b11, 2);
 
@@ -191,7 +186,6 @@ impl AccessAssign {
 
                 // Uplink usage marker
                 buf.write_bits(uplink_usage_marker.to_usage_marker().unwrap() as u64, 6);
-
             }
         }
     }
@@ -200,16 +194,40 @@ impl AccessAssign {
 impl fmt::Display for AccessAssign {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AccessAssign::DownlinkCommonControlUplinkCommonOnly { access_field_1, access_field_2 } => {
-                write!(f, "AccessAssign {{ DL: Common Ctrl, UL: Common Only, af1: {}, af2: {} }}", access_field_1, access_field_2)
-            },
-            AccessAssign::DownlinkDefinedUplinkCommonAndAssigned { downlink_usage_marker, access_field } => {
-                write!(f, "AccessAssign {{ DL: {}, UL: Common & Assigned, af: {} }}", downlink_usage_marker, access_field)
-            },
-            AccessAssign::DownlinkDefinedUplinkAssignedOnly { downlink_usage_marker, access_field } => {
-                write!(f, "AccessAssign {{ DL: {}, UL: Assigned Only, af: {} }}", downlink_usage_marker, access_field)
-            },
-            AccessAssign::DownlinkDefinedUplinkDefined { downlink_usage_marker, uplink_usage_marker } => {
+            AccessAssign::DownlinkCommonControlUplinkCommonOnly {
+                access_field_1,
+                access_field_2,
+            } => {
+                write!(
+                    f,
+                    "AccessAssign {{ DL: Common Ctrl, UL: Common Only, af1: {}, af2: {} }}",
+                    access_field_1, access_field_2
+                )
+            }
+            AccessAssign::DownlinkDefinedUplinkCommonAndAssigned {
+                downlink_usage_marker,
+                access_field,
+            } => {
+                write!(
+                    f,
+                    "AccessAssign {{ DL: {}, UL: Common & Assigned, af: {} }}",
+                    downlink_usage_marker, access_field
+                )
+            }
+            AccessAssign::DownlinkDefinedUplinkAssignedOnly {
+                downlink_usage_marker,
+                access_field,
+            } => {
+                write!(
+                    f,
+                    "AccessAssign {{ DL: {}, UL: Assigned Only, af: {} }}",
+                    downlink_usage_marker, access_field
+                )
+            }
+            AccessAssign::DownlinkDefinedUplinkDefined {
+                downlink_usage_marker,
+                uplink_usage_marker,
+            } => {
                 write!(f, "AccessAssign {{ DL: {}, UL: {} }}", downlink_usage_marker, uplink_usage_marker)
             }
         }

--- a/crates/tetra-pdus/src/umac/pdus/access_assign_fr18.rs
+++ b/crates/tetra-pdus/src/umac/pdus/access_assign_fr18.rs
@@ -1,41 +1,39 @@
+use crate::umac::pdus::access_assign::{AccessCode, BaseFrameLength};
+use crate::umac::{enums::access_assign_ul_usage::AccessAssignUlUsage, pdus::access_assign::AccessField};
 use core::fmt;
 use std::panic;
 use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
-use crate::umac::{enums::access_assign_ul_usage::AccessAssignUlUsage, pdus::access_assign::AccessField};
-use crate::umac::pdus::access_assign::{AccessCode, BaseFrameLength};
 
 /// Clause 21.4.7.2 ACCESS-ASSIGN
 #[derive(Debug)]
 pub enum AccessAssignFr18 {
-
     // Header = 00
     // Uplink access rights - common only
     UplinkCommonOnly {
         access_field_1: AccessField,
-        access_field_2: AccessField
+        access_field_2: AccessField,
     },
 
     // Header = 01
     // Uplink access rights - common and assigned
     UplinkCommonAndAssigned {
         access_field_1: AccessField,
-        access_field_2: AccessField
+        access_field_2: AccessField,
     },
 
     // Header = 10
     // Uplink access rights - assigned only
     UplinkAssignedOnly {
         access_field_1: AccessField,
-        access_field_2: AccessField
+        access_field_2: AccessField,
     },
 
     // Header = 11
     // Uplink access rights - common and assigned, but with traffic usage marker (UMt) instead of AF1
     UplinkCommonAndAssignedTraffic {
         uplink_usage_marker: AccessAssignUlUsage,
-        access_field: AccessField
-    }
-
+        access_field: AccessField,
+    },
 }
 
 impl Default for AccessAssignFr18 {
@@ -54,52 +52,73 @@ impl Default for AccessAssignFr18 {
 }
 
 impl AccessAssignFr18 {
-
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-
         let header = buf.read_field(2, "_header")?;
-        let field1 = buf.read_field(6, "field1")? ;
+        let field1 = buf.read_field(6, "field1")?;
         let field2 = buf.read_field(6, "field2")?;
 
         match header {
-
             0b00 => {
                 // Uplink access rights - common only
                 Ok(AccessAssignFr18::UplinkCommonOnly {
-                    access_field_1: field1.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_1", value: field1 })?,
-                    access_field_2: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_2", value: field2 })?,
+                    access_field_1: field1.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_1",
+                        value: field1,
+                    })?,
+                    access_field_2: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_2",
+                        value: field2,
+                    })?,
                 })
             }
 
             0b01 => {
                 // Uplink access rights - common and assigned
                 Ok(AccessAssignFr18::UplinkCommonAndAssigned {
-                    access_field_1: field1.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_1", value: field1 })?,
-                    access_field_2: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_2", value: field2 })?,
+                    access_field_1: field1.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_1",
+                        value: field1,
+                    })?,
+                    access_field_2: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_2",
+                        value: field2,
+                    })?,
                 })
             }
 
             0b10 => {
                 // Uplink access rights - assigned only
                 Ok(AccessAssignFr18::UplinkAssignedOnly {
-                    access_field_1: field1.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_1", value: field1 })?,
-                    access_field_2: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field_2", value: field2 })?,
+                    access_field_1: field1.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_1",
+                        value: field1,
+                    })?,
+                    access_field_2: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field_2",
+                        value: field2,
+                    })?,
                 })
             }
 
             0b11 => {
                 // Uplink access rights - common and assigned, but with traffic usage marker (UMt) instead of AF1
+                let uplink_usage_marker = AccessAssignUlUsage::from_usage_marker(field1 as u8).ok_or(PduParseErr::InvalidValue {
+                    field: "uplink_usage_marker",
+                    value: field1,
+                })?;
+                // Table 21.82 mandates UMt for header=11. UMx and other non-traffic markers are forbidden.
+                if !uplink_usage_marker.is_traffic() {
+                    return Err(PduParseErr::InvalidValue {
+                        field: "uplink_usage_marker",
+                        value: field1,
+                    });
+                }
                 Ok(AccessAssignFr18::UplinkCommonAndAssignedTraffic {
-                    uplink_usage_marker: AccessAssignUlUsage::from_usage_marker(field1 as u8)
-                        .ok_or(PduParseErr::InvalidValue { field: "uplink_usage_marker", value: field1 })?,
-                    access_field: field2.try_into()
-                        .map_err(|_| PduParseErr::InvalidValue { field: "access_field", value: field2 })?,
+                    uplink_usage_marker,
+                    access_field: field2.try_into().map_err(|_| PduParseErr::InvalidValue {
+                        field: "access_field",
+                        value: field2,
+                    })?,
                 })
             }
 
@@ -110,14 +129,11 @@ impl AccessAssignFr18 {
     }
 
     pub fn to_bitbuf(&self, buf: &mut BitBuffer) {
-
         match self {
-
             AccessAssignFr18::UplinkCommonOnly {
                 access_field_1,
-                access_field_2
+                access_field_2,
             } => {
-
                 // Header = 00
                 buf.write_bits(0b00, 2);
 
@@ -126,14 +142,12 @@ impl AccessAssignFr18 {
 
                 // Access field 2
                 buf.write_bits(access_field_2.into_raw(), 6);
-
-            },
+            }
 
             AccessAssignFr18::UplinkCommonAndAssigned {
                 access_field_1,
-                access_field_2
+                access_field_2,
             } => {
-
                 // Header = 01
                 buf.write_bits(0b01, 2);
 
@@ -142,14 +156,12 @@ impl AccessAssignFr18 {
 
                 // Access field 2
                 buf.write_bits(access_field_2.into_raw(), 6);
-
-            },
+            }
 
             AccessAssignFr18::UplinkAssignedOnly {
                 access_field_1,
-                access_field_2
+                access_field_2,
             } => {
-
                 // Header = 10
                 buf.write_bits(0b10, 2);
 
@@ -158,14 +170,12 @@ impl AccessAssignFr18 {
 
                 // Access field 2
                 buf.write_bits(access_field_2.into_raw(), 6);
-
-            },
+            }
 
             AccessAssignFr18::UplinkCommonAndAssignedTraffic {
                 uplink_usage_marker,
-                access_field
+                access_field,
             } => {
-
                 // Header = 11
                 buf.write_bits(0b11, 2);
 
@@ -173,8 +183,8 @@ impl AccessAssignFr18 {
                 buf.write_bits(uplink_usage_marker.to_usage_marker().unwrap() as u64, 6);
 
                 // Access field (both subslots)
-                buf.write_bits(access_field.into_raw(), 6);}
-
+                buf.write_bits(access_field.into_raw(), 6);
+            }
         }
     }
 }
@@ -182,17 +192,45 @@ impl AccessAssignFr18 {
 impl fmt::Display for AccessAssignFr18 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AccessAssignFr18::UplinkCommonOnly { access_field_1, access_field_2 } => {
-                write!(f, "AccessAssignFr18 {{ UplinkCommonOnly: af1: {}, af2: {} }}", access_field_1, access_field_2)
-            },
-            AccessAssignFr18::UplinkCommonAndAssigned { access_field_1, access_field_2 } => {
-                write!(f, "AccessAssignFr18 {{ UplinkCommonAndAssigned: af1: {}, af2: {} }}", access_field_1, access_field_2)
-            },
-            AccessAssignFr18::UplinkAssignedOnly { access_field_1, access_field_2 } => {
-                write!(f, "AccessAssignFr18 {{ UplinkAssignedOnly: af1: {}, af2: {} }}", access_field_1, access_field_2)
-            },
-            AccessAssignFr18::UplinkCommonAndAssignedTraffic { uplink_usage_marker, access_field } => {
-                write!(f, "AccessAssignFr18 {{ UplinkCommonAndAssignedTraffic: uum: {}, af: {} }}", uplink_usage_marker, access_field)
+            AccessAssignFr18::UplinkCommonOnly {
+                access_field_1,
+                access_field_2,
+            } => {
+                write!(
+                    f,
+                    "AccessAssignFr18 {{ UplinkCommonOnly: af1: {}, af2: {} }}",
+                    access_field_1, access_field_2
+                )
+            }
+            AccessAssignFr18::UplinkCommonAndAssigned {
+                access_field_1,
+                access_field_2,
+            } => {
+                write!(
+                    f,
+                    "AccessAssignFr18 {{ UplinkCommonAndAssigned: af1: {}, af2: {} }}",
+                    access_field_1, access_field_2
+                )
+            }
+            AccessAssignFr18::UplinkAssignedOnly {
+                access_field_1,
+                access_field_2,
+            } => {
+                write!(
+                    f,
+                    "AccessAssignFr18 {{ UplinkAssignedOnly: af1: {}, af2: {} }}",
+                    access_field_1, access_field_2
+                )
+            }
+            AccessAssignFr18::UplinkCommonAndAssignedTraffic {
+                uplink_usage_marker,
+                access_field,
+            } => {
+                write!(
+                    f,
+                    "AccessAssignFr18 {{ UplinkCommonAndAssignedTraffic: uum: {}, af: {} }}",
+                    uplink_usage_marker, access_field
+                )
             }
         }
     }


### PR DESCRIPTION
- Return InvalidValue instead of panicking on reserved UL usage marker (ETSI 21.81 NOTE 2)
- Reject non-traffic UMt on frame 18 header=11 per ETSI 21.82
- Bounds-check is_hangtime timeslot to prevent underflow
- Downgrade dl_drop_all_except_stolen warn to debug, fires on normal hangtime race