### PR TITLE
Bug fixes and improvements

### DIFF
--- a/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
+++ b/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
@@ -315,7 +315,11 @@ impl CircuitMgr {
                     // Send D-SETUP for the initial frame + 1 backup frame after circuit creation.
                     // Matches ETSI Annex D Figure D.2: 1 initial + 1 back-up on MCCH.
                     if age < frames!(D_SETUP_REPEATS) {
-                        tracing::debug!("CircuitMgr: Sending initial D-SETUP backup for circuit {:?} (age {} frames)", circuit, age);
+                        tracing::debug!(
+                            "CircuitMgr: Sending initial D-SETUP backup for circuit {:?} (age {} frames)",
+                            circuit,
+                            age
+                        );
                         tasks
                             .get_or_insert_with(Vec::new)
                             .push(CircuitMgrCmd::SendDSetup(circuit.call_id, circuit.usage, circuit.ts));
@@ -324,7 +328,11 @@ impl CircuitMgr {
                     // Compare in frames (age/4) since tick_start only fires on t==1
                     // but ts_created may have any timeslot value.
                     else if (age / 4) % (LATE_ENTRY_INTERVAL_TIMESLOTS / 4) == 0 {
-                        tracing::debug!("CircuitMgr: Sending late-entry D-SETUP for circuit {:?} (age {} frames)", circuit, age);
+                        tracing::debug!(
+                            "CircuitMgr: Sending late-entry D-SETUP for circuit {:?} (age {} frames)",
+                            circuit,
+                            age
+                        );
                         tasks
                             .get_or_insert_with(Vec::new)
                             .push(CircuitMgrCmd::SendDSetup(circuit.call_id, circuit.usage, circuit.ts));

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs.rs
@@ -50,6 +50,9 @@ pub struct CcBsSubentity {
     subscriber_groups: HashMap<u32, HashSet<u32>>,
     /// Listener counts per GSSI
     group_listeners: HashMap<u32, usize>,
+    /// Calls whose D-RELEASE has been sent and whose circuit teardown is deferred a few
+    /// frames so the stolen D-RELEASE transmits. These are no longer in active_calls.
+    releasing_calls: Vec<ReleasingCall>,
 }
 
 /// Origin of a group call
@@ -63,6 +66,20 @@ enum CallOrigin {
     Network {
         brew_uuid: uuid::Uuid, // For Brew tracking
     },
+}
+
+/// A call being released. The call is removed from active_calls when this is created, so
+/// it cannot be re-keyed or reused. D-RELEASE is stolen onto the traffic channel (it only
+/// transmits while the slot is in traffic mode) at sent_at, then the circuit is closed a
+/// couple frames later. Carries everything teardown needs, since the active_calls entry is
+/// already gone.
+struct ReleasingCall {
+    call_id: u16,
+    ts: u8,
+    dest_gssi: u32,
+    is_local: bool,
+    brew_uuid: Option<uuid::Uuid>,
+    sent_at: TdmaTime,
 }
 
 /// Tracks an active group call (local or network-initiated)
@@ -92,6 +109,7 @@ impl CcBsSubentity {
             active_calls: HashMap::new(),
             subscriber_groups: HashMap::new(),
             group_listeners: HashMap::new(),
+            releasing_calls: Vec::new(),
         }
     }
 
@@ -636,6 +654,9 @@ impl CcBsSubentity {
         // Check hangtime expiry for active local calls
         self.check_hangtime_expiry(queue);
 
+        // Drive deferred D-RELEASE teardown
+        self.process_releasing_calls(queue);
+
         if let Some(tasks) = self.circuits.tick_start(dltime) {
             for task in tasks {
                 match task {
@@ -750,82 +771,113 @@ impl CcBsSubentity {
         }
     }
 
-    /// Release a call: send D-RELEASE, close circuits, clean up state
+    /// Release a call. Removes it from active state immediately so it cannot be re-keyed
+    /// or reused, steals one D-RELEASE onto the traffic channel, and parks the teardown in
+    /// releasing_calls. The circuit and timeslot stay allocated until process_releasing_calls
+    /// tears them down, which lets the stolen D-RELEASE transmit before the slot leaves
+    /// traffic mode. With no cached D-SETUP there is no D-RELEASE to send, so it tears down
+    /// at once.
     fn release_call(&mut self, queue: &mut MessageQueue, call_id: u16, disconnect_cause: DisconnectCause) {
-        // Build D-RELEASE if we still have the cached setup. Missing cache must not
-        // skip the cleanup below, otherwise hangtime expiry refires release_call every tick.
-        if let Some((pdu, dest_addr, _)) = self.cached_setups.get(&call_id) {
-            let dest_addr = *dest_addr;
-            let sdu = Self::build_d_release_from_d_setup(pdu, disconnect_cause);
-            let prim = if let Some(ts) = self.active_calls.get(&call_id).map(|c| c.ts) {
-                Self::build_sapmsg_stealing(sdu, dest_addr, ts)
+        let Some(call) = self.active_calls.remove(&call_id) else {
+            return;
+        };
+        let ts = call.ts;
+        let dest_gssi = call.dest_gssi;
+        let is_local = matches!(call.origin, CallOrigin::Local { .. });
+        // Prefer the live brew_uuid (current network speaker). Fall back to the origin uuid
+        // for a Network call in hangtime, where rx_network_call_end cleared the field.
+        let brew_uuid = call.brew_uuid.or(match call.origin {
+            CallOrigin::Network { brew_uuid } => Some(brew_uuid),
+            CallOrigin::Local { .. } => None,
+        });
+
+        match self.cached_setups.remove(&call_id) {
+            Some((d_setup, dest_addr, _)) => {
+                let sdu = Self::build_d_release_from_d_setup(&d_setup, disconnect_cause);
+                queue.push_back(Self::build_sapmsg_stealing(sdu, dest_addr, ts));
+                self.releasing_calls.push(ReleasingCall {
+                    call_id,
+                    ts,
+                    dest_gssi,
+                    is_local,
+                    brew_uuid,
+                    sent_at: self.dltime,
+                });
+            }
+            None => {
+                tracing::warn!("No cached D-SETUP for call_id={}, cleaning up without D-RELEASE", call_id);
+                self.finalize_release(queue, call_id, ts, dest_gssi, is_local, brew_uuid);
+            }
+        }
+    }
+
+    /// Close a releasing call's circuit once enough frames have passed since the D-RELEASE
+    /// was stolen for it to transmit. Driven once per tick.
+    fn process_releasing_calls(&mut self, queue: &mut MessageQueue) {
+        // Two TDMA frames: the stolen D-RELEASE drains over the next frame while the slot
+        // is still in traffic mode, then teardown one frame later.
+        const CLOSE_AFTER_SEND_TS: i32 = 8;
+
+        let now = self.dltime;
+        let mut i = 0;
+        while i < self.releasing_calls.len() {
+            if self.releasing_calls[i].sent_at.age(now) >= CLOSE_AFTER_SEND_TS {
+                let rc = self.releasing_calls.remove(i);
+                self.finalize_release(queue, rc.call_id, rc.ts, rc.dest_gssi, rc.is_local, rc.brew_uuid);
             } else {
-                tracing::warn!(
-                    "release_call: no active call state for call_id={}, sending D-RELEASE on MCCH",
-                    call_id
-                );
-                Self::build_sapmsg(sdu, None, dest_addr, Layer2Service::Unacknowledged, None)
-            };
-            queue.push_back(prim);
-        } else {
-            tracing::warn!("No cached D-SETUP for call_id={}, cleaning up anyway", call_id);
-        }
-
-        // Close the circuit in CircuitMgr and notify Brew
-        if let Some(call) = self.active_calls.get(&call_id) {
-            let ts = call.ts;
-            let dest_ssi = call.dest_gssi;
-            let is_local = matches!(call.origin, CallOrigin::Local { .. });
-            // Prefer the live brew_uuid field (tracks current network speaker on both
-            // Local and Network origins). Fall back to the origin uuid for a Network call
-            // sitting in hangtime, where rx_network_call_end has cleared the field.
-            let brew_uuid = call.brew_uuid.or(match call.origin {
-                CallOrigin::Network { brew_uuid } => Some(brew_uuid),
-                CallOrigin::Local { .. } => None,
-            });
-
-            if let Ok(circuit) = self.circuits.close_circuit(Direction::Both, ts) {
-                Self::signal_umac_circuit_close(queue, circuit);
-            }
-
-            // Ensure UMAC clears hangtime even if the CMCE circuit was already closed above.
-            queue.push_back(SapMsg {
-                sap: Sap::Control,
-                src: TetraEntity::Cmce,
-                dest: TetraEntity::Umac,
-                msg: SapMsgInner::CmceCallControl(CallControl::CallEnded { call_id, ts }),
-            });
-
-            self.release_timeslot(ts);
-
-            // Tell Brew the call is gone. Local-origin calls get CallEnded so Brew clears
-            // ul_forwarded[ts] from any earlier UL forwarding. If a network speaker was
-            // ever involved (active or in hangtime), also send NetworkCallEnd so Brew
-            // tears down the upstream session. Without the latter, hangtime expiry leaves
-            // Brew thinking the circuit is still reusable and the backend keeps streaming.
-            if net_brew::is_brew_gssi_routable(&self.config, dest_ssi) {
-                if is_local {
-                    queue.push_back(SapMsg {
-                        sap: Sap::Control,
-                        src: TetraEntity::Cmce,
-                        dest: TetraEntity::Brew,
-                        msg: SapMsgInner::CmceCallControl(CallControl::CallEnded { call_id, ts }),
-                    });
-                }
-                if let Some(brew_uuid) = brew_uuid {
-                    queue.push_back(SapMsg {
-                        sap: Sap::Control,
-                        src: TetraEntity::Cmce,
-                        dest: TetraEntity::Brew,
-                        msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid }),
-                    });
-                }
+                i += 1;
             }
         }
+    }
 
-        // Always clean up. See note above about the per-tick loop.
-        self.cached_setups.remove(&call_id);
-        self.active_calls.remove(&call_id);
+    /// Tear down a released call: close the circuit, free the timeslot, notify Brew.
+    /// The active_calls and cached_setups entries were already removed in release_call.
+    fn finalize_release(
+        &mut self,
+        queue: &mut MessageQueue,
+        call_id: u16,
+        ts: u8,
+        dest_gssi: u32,
+        is_local: bool,
+        brew_uuid: Option<uuid::Uuid>,
+    ) {
+        if let Ok(circuit) = self.circuits.close_circuit(Direction::Both, ts) {
+            Self::signal_umac_circuit_close(queue, circuit);
+        }
+
+        // Ensure UMAC clears hangtime even if the CMCE circuit was already closed above.
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Umac,
+            msg: SapMsgInner::CmceCallControl(CallControl::CallEnded { call_id, ts }),
+        });
+
+        self.release_timeslot(ts);
+
+        // Tell Brew the call is gone. Local-origin calls get CallEnded so Brew clears
+        // ul_forwarded[ts] from any earlier UL forwarding. If a network speaker was
+        // ever involved (active or in hangtime), also send NetworkCallEnd so Brew
+        // tears down the upstream session. Without the latter, hangtime expiry leaves
+        // Brew thinking the circuit is still reusable and the backend keeps streaming.
+        if net_brew::is_brew_gssi_routable(&self.config, dest_gssi) {
+            if is_local {
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Cmce,
+                    dest: TetraEntity::Brew,
+                    msg: SapMsgInner::CmceCallControl(CallControl::CallEnded { call_id, ts }),
+                });
+            }
+            if let Some(brew_uuid) = brew_uuid {
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Cmce,
+                    dest: TetraEntity::Brew,
+                    msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid }),
+                });
+            }
+        }
     }
 
     fn feature_check_u_setup(pdu: &USetup) -> bool {

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -361,6 +361,26 @@ impl BrewEntity {
             return;
         }
 
+        // New UUID on a GSSI that still has an active call. Backend started a new
+        // session without idling the old one. Evict the stale entry so active_calls
+        // and dl_jitter do not leak. Local cleanup only. Backend owns downlink
+        // teardown and CMCE reuses the existing circuit for that GSSI.
+        if let Some(stale_uuid) = self
+            .active_calls
+            .iter()
+            .find(|(u, c)| c.dest_gssi == dest_gssi && **u != uuid)
+            .map(|(u, _)| *u)
+        {
+            tracing::warn!(
+                "BrewEntity: backend started uuid={} on gssi={} without idling old uuid={}, evicting stale entry",
+                uuid,
+                dest_gssi,
+                stale_uuid
+            );
+            self.active_calls.remove(&stale_uuid);
+            self.dl_jitter.remove(&stale_uuid);
+        }
+
         // Check if there's a hanging call we can reuse
         if let Some(hanging) = self.hanging_calls.remove(&dest_gssi) {
             tracing::info!(

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -1567,6 +1567,70 @@ mod tests {
         assert!(sched.dltx_queues[ts.t as usize - 1].len() == 1);
     }
 
+    fn decode_aach(sched: &BsChannelScheduler, ts: TdmaTime) -> AccessAssign {
+        let bbk = sched.generate_bbk_block(ts);
+        let mut buf = bbk.mac_block.clone();
+        buf.seek(0);
+        AccessAssign::from_bitbuf(&mut buf).expect("Failed to decode AACH block")
+    }
+
+    /// During hangtime the AACH must hold AssignedControl on every frame, including
+    /// frames carrying a pending stolen block. If it flapped back to the traffic
+    /// usage marker, the end-of-traffic detector (N.212 successive non-UMt
+    /// ACCESS-ASSIGN PDUs, ETSI 23.8.2.3.2) would reset its count.
+    #[test]
+    fn test_hangtime_marker_does_not_flap_on_pending_stealing() {
+        use tetra_saps::control::call_control::Circuit;
+        use tetra_saps::control::enums::circuit_mode_type::CircuitModeType;
+
+        let mut sched = get_testing_slotter();
+        let ts = TdmaTime { t: 2, f: 1, m: 1, h: 0 };
+
+        sched.create_circuit(
+            Direction::Dl,
+            Circuit {
+                direction: Direction::Dl,
+                ts: 2,
+                usage: 6,
+                circuit_mode: CircuitModeType::TchS,
+                speech_service: Some(0),
+                etee_encrypted: false,
+            },
+        );
+
+        // Active over: traffic usage marker (UMt).
+        assert!(
+            decode_aach(&sched, ts).dl_is_traffic(),
+            "active over should carry the traffic usage marker"
+        );
+
+        // Hangtime, no pending steal: AssignedControl, not traffic.
+        sched.set_hangtime(2, true);
+        let aach = decode_aach(&sched, ts);
+        assert!(!aach.dl_is_traffic(), "hangtime should drop the traffic usage marker");
+        assert!(
+            matches!(
+                aach,
+                AccessAssign::DownlinkDefinedUplinkAssignedOnly {
+                    downlink_usage_marker: AccessAssignDlUsage::AssignedControl,
+                    ..
+                }
+            ),
+            "hangtime AACH should be AssignedControl, got {:?}",
+            aach
+        );
+
+        // Hangtime with a pending stolen block: still AssignedControl, no flap to UMt.
+        sched.dl_enqueue_stealing(2, BitBuffer::from_bitstr("10110000"), None);
+        assert!(sched.has_pending_stealing(2), "stealing block should be queued");
+        let aach = decode_aach(&sched, ts);
+        assert!(
+            !aach.dl_is_traffic(),
+            "hangtime marker must not flap back to traffic while a steal is pending, got {:?}",
+            aach
+        );
+    }
+
     #[test]
     fn test_dl_indicates_reserved_subslots() {
         let mut sched = get_testing_slotter();

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -651,10 +651,16 @@ impl UmacBs {
             return;
         }
 
-        // Schedule acknowledgement of this message
-        // let ul_time = message.dltime.add_timeslots(-2);
-        let msg_dltime = self.dltime.add_timeslots(-2); // Msg on uplink was sent two timeslots ago. 
-        self.channel_scheduler.dl_enqueue_random_access_ack(msg_dltime.t, addr);
+        // Acknowledge the access, unless it is on a timeslot in an active over. During
+        // traffic the uplink is reserved (ETSI 23.5.1.3), so the talker is not on random
+        // access and acking it would steal an extra MAC-RESOURCE onto the traffic channel.
+        // Hangtime and control-channel access (floor requests) are still acked.
+        let msg_dltime = self.dltime.add_timeslots(-2); // Msg on uplink was sent two timeslots ago.
+        let in_active_over =
+            self.channel_scheduler.circuit_is_active(Direction::Dl, msg_dltime.t) && !self.channel_scheduler.is_hangtime(msg_dltime.t);
+        if !in_active_over {
+            self.channel_scheduler.dl_enqueue_random_access_ack(msg_dltime.t, addr);
+        }
 
         // Decrypt if needed
         if pdu.encrypted {

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1111,6 +1111,7 @@ impl UmacBs {
                 // Build MAC-RESOURCE PDU for the STCH half-slot (124 type1 bits).
                 // Same format as MCCH signaling, just in 124 bits instead of 268.
                 const STCH_CAP: usize = 124;
+                const NULL_PDU_LEN_BITS: usize = 16;
 
                 let usage_marker = prim.chan_alloc.as_ref().and_then(|ca| ca.usage);
                 // Per ETSI 21.4.3.1: "The random access flag shall be used for the BS to
@@ -1134,7 +1135,7 @@ impl UmacBs {
                     slot_granting_element: None,
                     chan_alloc_element: None,
                 };
-                mac_pdu.update_len_and_fill_ind(sdu.get_len());
+                let num_fill_bits = mac_pdu.update_len_and_fill_ind(sdu.get_len());
 
                 let mut stch_block = BitBuffer::new(STCH_CAP);
                 mac_pdu.to_bitbuf(&mut stch_block);
@@ -1144,7 +1145,24 @@ impl UmacBs {
                 sdu.seek(0);
                 let sdu_len = sdu.get_len();
                 stch_block.copy_bits(&mut sdu, sdu_len);
-                // Remaining bits beyond length_ind are ignored by the receiver.
+
+                // ETSI 23.4.3.1 fill bit addition: a '1' immediately after the TM-SDU,
+                // then zeros up to the indicated length. Without the leading '1', a
+                // receiver performing the mandated fill bit deletion (23.4.3.2) strips
+                // backwards past the fill region into the PDU and corrupts its tail.
+                fillbits::addition::write(&mut stch_block, Some(num_fill_bits));
+
+                // Complete the remaining half-slot capacity with a Null PDU followed by
+                // a '1' and zeros (ETSI 23.4.2.2), instead of leaving raw zeros.
+                if stch_block.get_len_remaining() >= NULL_PDU_LEN_BITS {
+                    let mut null_pdu = MacResource::null_pdu();
+                    let _ = null_pdu.update_len_and_fill_ind(0);
+                    null_pdu.to_bitbuf(&mut stch_block);
+                }
+                if stch_block.get_len_remaining() > 0 {
+                    stch_block.write_bit(1);
+                    // Rest of the buffer is already zeroed.
+                }
 
                 tracing::info!(
                     "rx_ul_tma_unitdata_req: FACCH stealing on ts {} (MAC-RESOURCE + {} SDU bits → {} STCH bits)",

--- a/crates/tetra-entities/src/umac/umac_ms.rs
+++ b/crates/tetra-entities/src/umac/umac_ms.rs
@@ -569,7 +569,6 @@ impl UmacMs {
             };
 
             pdu.dl_is_traffic()
-
         } else {
             let _pdu = match AccessAssignFr18::from_bitbuf(&mut prim.pdu) {
                 Ok(pdu) => {

--- a/crates/tetra-pdus/src/umac/enums/access_code.rs
+++ b/crates/tetra-pdus/src/umac/enums/access_code.rs
@@ -6,7 +6,7 @@ pub enum AccessCode {
     AccessCodeA,
     AccessCodeB,
     AccessCodeC,
-    AccessCodeD
+    AccessCodeD,
 }
 
 impl TryFrom<u64> for AccessCode {

--- a/crates/tetra-pdus/src/umac/enums/mod.rs
+++ b/crates/tetra-pdus/src/umac/enums/mod.rs
@@ -1,3 +1,6 @@
+pub mod access_assign_dl_usage;
+pub mod access_assign_ul_usage;
+pub mod access_code;
 pub mod basic_slotgrant_cap_alloc;
 pub mod basic_slotgrant_granting_delay;
 pub mod broadcast_type;
@@ -5,6 +8,3 @@ pub mod mac_pdu_type;
 pub mod mac_resource_addr_type;
 pub mod reservation_requirement;
 pub mod sysinfo_opt_field_flag;
-pub mod access_assign_dl_usage;
-pub mod access_assign_ul_usage;
-pub mod access_code;

--- a/crates/tetra-pdus/src/umac/structs/access_field.rs
+++ b/crates/tetra-pdus/src/umac/structs/access_field.rs
@@ -1,6 +1,6 @@
-use core::fmt;
 use crate::umac::enums::access_code::AccessCode;
 use crate::umac::structs::base_frame_length::BaseFrameLength;
+use core::fmt;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AccessField {
@@ -30,4 +30,3 @@ impl fmt::Display for AccessField {
         write!(f, "Access Code: {}, Base Frame Length: {}", self.access_code, self.base_frame_len)
     }
 }
-

--- a/crates/tetra-pdus/src/umac/structs/base_frame_length.rs
+++ b/crates/tetra-pdus/src/umac/structs/base_frame_length.rs
@@ -2,7 +2,6 @@ use core::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BaseFrameLength {
-
     /// Essentially "already assigned" - Access Code is meaningless in this Access Field
     ReservedSubslot,
 
@@ -25,7 +24,7 @@ pub enum BaseFrameLength {
     Subslots16,
     Subslots20,
     Subslots24,
-    Subslots32
+    Subslots32,
 }
 
 impl TryFrom<u64> for BaseFrameLength {
@@ -71,7 +70,7 @@ impl BaseFrameLength {
             BaseFrameLength::Subslots16 => 0b1100,
             BaseFrameLength::Subslots20 => 0b1101,
             BaseFrameLength::Subslots24 => 0b1110,
-            BaseFrameLength::Subslots32 => 0b1111
+            BaseFrameLength::Subslots32 => 0b1111,
         }
     }
 }
@@ -94,7 +93,7 @@ impl fmt::Display for BaseFrameLength {
             BaseFrameLength::Subslots16 => write!(f, "16 Subslots"),
             BaseFrameLength::Subslots20 => write!(f, "20 Subslots"),
             BaseFrameLength::Subslots24 => write!(f, "24 Subslots"),
-            BaseFrameLength::Subslots32 => write!(f, "32 Subslots")
+            BaseFrameLength::Subslots32 => write!(f, "32 Subslots"),
         }
     }
 }

--- a/crates/tetra-pdus/src/umac/structs/mod.rs
+++ b/crates/tetra-pdus/src/umac/structs/mod.rs
@@ -1,3 +1,3 @@
-pub mod umac_circuit;
 pub mod access_field;
 pub mod base_frame_length;
+pub mod umac_circuit;


### PR DESCRIPTION
Group-call end-of-call signalling fixes.

- **STCH fill bits:** write the mandatory fill bits on stolen PDUs (D-TX CEASED, D-RELEASE, etc.) per ETSI 23.4.3.1. Receivers performing fill-bit deletion were stripping into the PDU tail and discarding it.
- **D-RELEASE transmission:** defer group-call teardown so the stolen D-RELEASE transmits while the slot is still in traffic mode, instead of being discarded when the circuit closes in the same pass.
- **Reserved uplink:** stop random-access-acking the talker during an active over (ETSI 23.5.1.3, uplink is reserved during traffic). Removes a spurious stolen MAC-RESOURCE on the traffic channel.
- **Stale Brew call:** evict the call on a backend-omitted GROUP_IDLE.
- Add hangtime AACH marker-stability regression test.